### PR TITLE
feat(infra): add Clean Architecture project structure

### DIFF
--- a/OpenTicket.sln
+++ b/OpenTicket.sln
@@ -1,0 +1,120 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{68632520-F5A2-4208-84A1-0EAEB5D5D051}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTicket.Ddd", "src\OpenTicket.Ddd\OpenTicket.Ddd.csproj", "{27514652-C4E2-4415-899E-DF2610DDA123}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTicket.Domain.Shared", "src\OpenTicket.Domain.Shared\OpenTicket.Domain.Shared.csproj", "{D86BD1B8-07A2-41A3-8B8A-DF4A2768FEFB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTicket.Domain", "src\OpenTicket.Domain\OpenTicket.Domain.csproj", "{49AE8EB5-AF81-4320-86FF-8616C171A2F1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTicket.Application.Contracts", "src\OpenTicket.Application.Contracts\OpenTicket.Application.Contracts.csproj", "{AE97F1DB-2B9E-4C33-87CB-AC49C146018B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTicket.Application", "src\OpenTicket.Application\OpenTicket.Application.csproj", "{C74711C1-F33B-4929-A2A2-5DA935EA2377}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTicket.Infrastructure", "src\OpenTicket.Infrastructure\OpenTicket.Infrastructure.csproj", "{082D2680-FD3F-4313-9ECC-1337FA491A91}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTicket.Infrastructure.Database", "src\OpenTicket.Infrastructure.Database\OpenTicket.Infrastructure.Database.csproj", "{87F69EEB-20E2-44C2-A364-1CE0101F72A2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTicket.Infrastructure.Payment", "src\OpenTicket.Infrastructure.Payment\OpenTicket.Infrastructure.Payment.csproj", "{08CA0556-49AB-49AE-B5D0-819222A30E5C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTicket.Infrastructure.Identity", "src\OpenTicket.Infrastructure.Identity\OpenTicket.Infrastructure.Identity.csproj", "{1E454A38-1267-4A60-99C7-209B06CB8D8D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTicket.Infrastructure.MessageBroker", "src\OpenTicket.Infrastructure.MessageBroker\OpenTicket.Infrastructure.MessageBroker.csproj", "{3A7FF0A2-36E5-4E6E-9A65-71E61F93E23A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTicket.Api", "src\OpenTicket.Api\OpenTicket.Api.csproj", "{61ABA3B3-0D88-4E9D-9D6E-C0C696C3E01B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{6A7B2C7C-33D7-445D-BCBD-8C1057CD0F72}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTicket.Domain.Tests", "tests\OpenTicket.Domain.Tests\OpenTicket.Domain.Tests.csproj", "{62CD6BDF-3A32-467E-B2C7-891391F725FD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTicket.Application.Tests", "tests\OpenTicket.Application.Tests\OpenTicket.Application.Tests.csproj", "{1C5F6F37-97E1-486A-95C7-7ABB1B5BBE4A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTicket.Infrastructure.Tests", "tests\OpenTicket.Infrastructure.Tests\OpenTicket.Infrastructure.Tests.csproj", "{80D243C1-5FCE-47B1-B264-E8DE131B6144}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{27514652-C4E2-4415-899E-DF2610DDA123}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27514652-C4E2-4415-899E-DF2610DDA123}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27514652-C4E2-4415-899E-DF2610DDA123}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27514652-C4E2-4415-899E-DF2610DDA123}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D86BD1B8-07A2-41A3-8B8A-DF4A2768FEFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D86BD1B8-07A2-41A3-8B8A-DF4A2768FEFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D86BD1B8-07A2-41A3-8B8A-DF4A2768FEFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D86BD1B8-07A2-41A3-8B8A-DF4A2768FEFB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49AE8EB5-AF81-4320-86FF-8616C171A2F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49AE8EB5-AF81-4320-86FF-8616C171A2F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49AE8EB5-AF81-4320-86FF-8616C171A2F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49AE8EB5-AF81-4320-86FF-8616C171A2F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE97F1DB-2B9E-4C33-87CB-AC49C146018B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE97F1DB-2B9E-4C33-87CB-AC49C146018B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE97F1DB-2B9E-4C33-87CB-AC49C146018B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE97F1DB-2B9E-4C33-87CB-AC49C146018B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C74711C1-F33B-4929-A2A2-5DA935EA2377}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C74711C1-F33B-4929-A2A2-5DA935EA2377}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C74711C1-F33B-4929-A2A2-5DA935EA2377}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C74711C1-F33B-4929-A2A2-5DA935EA2377}.Release|Any CPU.Build.0 = Release|Any CPU
+		{082D2680-FD3F-4313-9ECC-1337FA491A91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{082D2680-FD3F-4313-9ECC-1337FA491A91}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{082D2680-FD3F-4313-9ECC-1337FA491A91}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{082D2680-FD3F-4313-9ECC-1337FA491A91}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87F69EEB-20E2-44C2-A364-1CE0101F72A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87F69EEB-20E2-44C2-A364-1CE0101F72A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87F69EEB-20E2-44C2-A364-1CE0101F72A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87F69EEB-20E2-44C2-A364-1CE0101F72A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{08CA0556-49AB-49AE-B5D0-819222A30E5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08CA0556-49AB-49AE-B5D0-819222A30E5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08CA0556-49AB-49AE-B5D0-819222A30E5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08CA0556-49AB-49AE-B5D0-819222A30E5C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E454A38-1267-4A60-99C7-209B06CB8D8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E454A38-1267-4A60-99C7-209B06CB8D8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E454A38-1267-4A60-99C7-209B06CB8D8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E454A38-1267-4A60-99C7-209B06CB8D8D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3A7FF0A2-36E5-4E6E-9A65-71E61F93E23A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A7FF0A2-36E5-4E6E-9A65-71E61F93E23A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A7FF0A2-36E5-4E6E-9A65-71E61F93E23A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A7FF0A2-36E5-4E6E-9A65-71E61F93E23A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{61ABA3B3-0D88-4E9D-9D6E-C0C696C3E01B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{61ABA3B3-0D88-4E9D-9D6E-C0C696C3E01B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{61ABA3B3-0D88-4E9D-9D6E-C0C696C3E01B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{61ABA3B3-0D88-4E9D-9D6E-C0C696C3E01B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62CD6BDF-3A32-467E-B2C7-891391F725FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62CD6BDF-3A32-467E-B2C7-891391F725FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62CD6BDF-3A32-467E-B2C7-891391F725FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62CD6BDF-3A32-467E-B2C7-891391F725FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1C5F6F37-97E1-486A-95C7-7ABB1B5BBE4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1C5F6F37-97E1-486A-95C7-7ABB1B5BBE4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1C5F6F37-97E1-486A-95C7-7ABB1B5BBE4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1C5F6F37-97E1-486A-95C7-7ABB1B5BBE4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80D243C1-5FCE-47B1-B264-E8DE131B6144}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80D243C1-5FCE-47B1-B264-E8DE131B6144}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80D243C1-5FCE-47B1-B264-E8DE131B6144}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80D243C1-5FCE-47B1-B264-E8DE131B6144}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{27514652-C4E2-4415-899E-DF2610DDA123} = {68632520-F5A2-4208-84A1-0EAEB5D5D051}
+		{D86BD1B8-07A2-41A3-8B8A-DF4A2768FEFB} = {68632520-F5A2-4208-84A1-0EAEB5D5D051}
+		{49AE8EB5-AF81-4320-86FF-8616C171A2F1} = {68632520-F5A2-4208-84A1-0EAEB5D5D051}
+		{AE97F1DB-2B9E-4C33-87CB-AC49C146018B} = {68632520-F5A2-4208-84A1-0EAEB5D5D051}
+		{C74711C1-F33B-4929-A2A2-5DA935EA2377} = {68632520-F5A2-4208-84A1-0EAEB5D5D051}
+		{082D2680-FD3F-4313-9ECC-1337FA491A91} = {68632520-F5A2-4208-84A1-0EAEB5D5D051}
+		{87F69EEB-20E2-44C2-A364-1CE0101F72A2} = {68632520-F5A2-4208-84A1-0EAEB5D5D051}
+		{08CA0556-49AB-49AE-B5D0-819222A30E5C} = {68632520-F5A2-4208-84A1-0EAEB5D5D051}
+		{1E454A38-1267-4A60-99C7-209B06CB8D8D} = {68632520-F5A2-4208-84A1-0EAEB5D5D051}
+		{3A7FF0A2-36E5-4E6E-9A65-71E61F93E23A} = {68632520-F5A2-4208-84A1-0EAEB5D5D051}
+		{61ABA3B3-0D88-4E9D-9D6E-C0C696C3E01B} = {68632520-F5A2-4208-84A1-0EAEB5D5D051}
+		{62CD6BDF-3A32-467E-B2C7-891391F725FD} = {6A7B2C7C-33D7-445D-BCBD-8C1057CD0F72}
+		{1C5F6F37-97E1-486A-95C7-7ABB1B5BBE4A} = {6A7B2C7C-33D7-445D-BCBD-8C1057CD0F72}
+		{80D243C1-5FCE-47B1-B264-E8DE131B6144} = {6A7B2C7C-33D7-445D-BCBD-8C1057CD0F72}
+	EndGlobalSection
+EndGlobal

--- a/src/OpenTicket.Api/OpenTicket.Api.csproj
+++ b/src/OpenTicket.Api/OpenTicket.Api.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenTicket.Application\OpenTicket.Application.csproj" />
+    <ProjectReference Include="..\OpenTicket.Infrastructure\OpenTicket.Infrastructure.csproj" />
+    <ProjectReference Include="..\OpenTicket.Infrastructure.Database\OpenTicket.Infrastructure.Database.csproj" />
+    <ProjectReference Include="..\OpenTicket.Infrastructure.Payment\OpenTicket.Infrastructure.Payment.csproj" />
+    <ProjectReference Include="..\OpenTicket.Infrastructure.Identity\OpenTicket.Infrastructure.Identity.csproj" />
+    <ProjectReference Include="..\OpenTicket.Infrastructure.MessageBroker\OpenTicket.Infrastructure.MessageBroker.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/OpenTicket.Api/OpenTicket.Api.http
+++ b/src/OpenTicket.Api/OpenTicket.Api.http
@@ -1,0 +1,6 @@
+@OpenTicket.Api_HostAddress = http://localhost:5144
+
+GET {{OpenTicket.Api_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/src/OpenTicket.Api/Program.cs
+++ b/src/OpenTicket.Api/Program.cs
@@ -1,0 +1,41 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.UseHttpsRedirection();
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+{
+    var forecast =  Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
+    return forecast;
+})
+.WithName("GetWeatherForecast");
+
+app.Run();
+
+record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/src/OpenTicket.Api/Properties/launchSettings.json
+++ b/src/OpenTicket.Api/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5144",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7118;http://localhost:5144",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/OpenTicket.Api/appsettings.Development.json
+++ b/src/OpenTicket.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/OpenTicket.Api/appsettings.json
+++ b/src/OpenTicket.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/OpenTicket.Application.Contracts/OpenTicket.Application.Contracts.csproj
+++ b/src/OpenTicket.Application.Contracts/OpenTicket.Application.Contracts.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenTicket.Domain\OpenTicket.Domain.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/OpenTicket.Application/OpenTicket.Application.csproj
+++ b/src/OpenTicket.Application/OpenTicket.Application.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenTicket.Domain\OpenTicket.Domain.csproj" />
+    <ProjectReference Include="..\OpenTicket.Application.Contracts\OpenTicket.Application.Contracts.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/OpenTicket.Ddd/Application/IRepository.cs
+++ b/src/OpenTicket.Ddd/Application/IRepository.cs
@@ -1,0 +1,45 @@
+using OpenTicket.Ddd.Domain;
+
+namespace OpenTicket.Ddd.Application;
+
+/// <summary>
+/// Base interface for repositories. Repositories provide access to aggregates.
+/// </summary>
+/// <typeparam name="TAggregate">The aggregate root type.</typeparam>
+/// <typeparam name="TId">The identifier type.</typeparam>
+public interface IRepository<TAggregate, in TId>
+    where TAggregate : AggregateRoot<TId>
+    where TId : notnull
+{
+    /// <summary>
+    /// Gets an aggregate by its identifier. Returns error if not found.
+    /// </summary>
+    Task<TAggregate> GetAsync(TId id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Finds an aggregate by its identifier, returns null if not found.
+    /// </summary>
+    Task<TAggregate?> FindAsync(TId id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Inserts a new aggregate.
+    /// </summary>
+    Task InsertAsync(TAggregate aggregate, CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates an existing aggregate.
+    /// </summary>
+    Task UpdateAsync(TAggregate aggregate, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes an aggregate.
+    /// </summary>
+    Task DeleteAsync(TAggregate aggregate, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Repository for aggregates with Guid identifier (default).
+/// </summary>
+/// <typeparam name="TAggregate">The aggregate root type.</typeparam>
+public interface IRepository<TAggregate> : IRepository<TAggregate, Guid>
+    where TAggregate : AggregateRoot<Guid>;

--- a/src/OpenTicket.Ddd/Domain/AggregateRoot.cs
+++ b/src/OpenTicket.Ddd/Domain/AggregateRoot.cs
@@ -1,0 +1,29 @@
+namespace OpenTicket.Ddd.Domain;
+
+/// <summary>
+/// Base class for aggregate roots. Aggregates are consistency boundaries
+/// and the only entry point for modifying a cluster of entities.
+/// </summary>
+/// <typeparam name="TId">The type of the aggregate root identifier.</typeparam>
+public abstract class AggregateRoot<TId> : Entity<TId>
+    where TId : notnull
+{
+    private readonly List<IDomainEvent> _domainEvents = [];
+
+    public IReadOnlyList<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    protected void AddDomainEvent(IDomainEvent domainEvent)
+    {
+        _domainEvents.Add(domainEvent);
+    }
+
+    public void ClearDomainEvents()
+    {
+        _domainEvents.Clear();
+    }
+}
+
+/// <summary>
+/// Aggregate root with Guid identifier (default).
+/// </summary>
+public abstract class AggregateRoot : AggregateRoot<Guid>;

--- a/src/OpenTicket.Ddd/Domain/DomainEvent.cs
+++ b/src/OpenTicket.Ddd/Domain/DomainEvent.cs
@@ -1,0 +1,11 @@
+namespace OpenTicket.Ddd.Domain;
+
+/// <summary>
+/// Base record for domain events.
+/// Domain events represent something that happened in the domain.
+/// </summary>
+public abstract record DomainEvent : IDomainEvent
+{
+    public Guid EventId { get; init; } = Guid.NewGuid();
+    public DateTime OccurredAt { get; init; } = DateTime.UtcNow;
+}

--- a/src/OpenTicket.Ddd/Domain/Entity.cs
+++ b/src/OpenTicket.Ddd/Domain/Entity.cs
@@ -1,0 +1,43 @@
+namespace OpenTicket.Ddd.Domain;
+
+/// <summary>
+/// Base class for all entities with a strongly-typed identifier.
+/// </summary>
+/// <typeparam name="TId">The type of the entity identifier.</typeparam>
+public abstract class Entity<TId> : IEquatable<Entity<TId>>
+    where TId : notnull
+{
+    public TId Id { get; protected set; } = default!;
+
+    public override bool Equals(object? obj)
+    {
+        return obj is Entity<TId> entity && Equals(entity);
+    }
+
+    public bool Equals(Entity<TId>? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return EqualityComparer<TId>.Default.Equals(Id, other.Id);
+    }
+
+    public override int GetHashCode()
+    {
+        return EqualityComparer<TId>.Default.GetHashCode(Id);
+    }
+
+    public static bool operator ==(Entity<TId>? left, Entity<TId>? right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(Entity<TId>? left, Entity<TId>? right)
+    {
+        return !Equals(left, right);
+    }
+}
+
+/// <summary>
+/// Entity with Guid identifier (default).
+/// </summary>
+public abstract class Entity : Entity<Guid>;

--- a/src/OpenTicket.Ddd/Domain/Enumeration.cs
+++ b/src/OpenTicket.Ddd/Domain/Enumeration.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+
+namespace OpenTicket.Ddd.Domain;
+
+/// <summary>
+/// Base class for smart enumerations. Provides type-safe enum alternatives
+/// with behavior and additional data.
+/// </summary>
+/// <typeparam name="TEnum">The enumeration type.</typeparam>
+public abstract class Enumeration<TEnum> : IEquatable<Enumeration<TEnum>>
+    where TEnum : Enumeration<TEnum>
+{
+    private static readonly Lazy<Dictionary<int, TEnum>> AllItems = new(GetAllItems);
+    private static readonly Lazy<Dictionary<string, TEnum>> AllItemsByName = new(
+        () => AllItems.Value.Values.ToDictionary(item => item.Name, StringComparer.OrdinalIgnoreCase));
+
+    public int Id { get; }
+    public string Name { get; }
+
+    protected Enumeration(int id, string name)
+    {
+        Id = id;
+        Name = name;
+    }
+
+    public static IReadOnlyCollection<TEnum> GetAll() => AllItems.Value.Values.ToList().AsReadOnly();
+
+    public static TEnum? FromId(int id)
+    {
+        return AllItems.Value.TryGetValue(id, out var item) ? item : null;
+    }
+
+    public static TEnum? FromName(string name)
+    {
+        return AllItemsByName.Value.TryGetValue(name, out var item) ? item : null;
+    }
+
+    public bool Equals(Enumeration<TEnum>? other)
+    {
+        if (other is null) return false;
+        return GetType() == other.GetType() && Id == other.Id;
+    }
+
+    public override bool Equals(object? obj) => obj is Enumeration<TEnum> other && Equals(other);
+
+    public override int GetHashCode() => Id.GetHashCode();
+
+    public override string ToString() => Name;
+
+    public static bool operator ==(Enumeration<TEnum>? left, Enumeration<TEnum>? right) => Equals(left, right);
+
+    public static bool operator !=(Enumeration<TEnum>? left, Enumeration<TEnum>? right) => !Equals(left, right);
+
+    private static Dictionary<int, TEnum> GetAllItems()
+    {
+        return typeof(TEnum)
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(f => f.FieldType == typeof(TEnum))
+            .Select(f => (TEnum)f.GetValue(null)!)
+            .ToDictionary(item => item.Id);
+    }
+}

--- a/src/OpenTicket.Ddd/Domain/IDomainEvent.cs
+++ b/src/OpenTicket.Ddd/Domain/IDomainEvent.cs
@@ -1,0 +1,18 @@
+namespace OpenTicket.Ddd.Domain;
+
+/// <summary>
+/// Marker interface for domain events.
+/// Domain events represent something that happened in the domain.
+/// </summary>
+public interface IDomainEvent
+{
+    /// <summary>
+    /// The unique identifier for this event instance.
+    /// </summary>
+    Guid EventId { get; }
+
+    /// <summary>
+    /// When the event occurred.
+    /// </summary>
+    DateTime OccurredAt { get; }
+}

--- a/src/OpenTicket.Ddd/Domain/ValueObject.cs
+++ b/src/OpenTicket.Ddd/Domain/ValueObject.cs
@@ -1,0 +1,39 @@
+namespace OpenTicket.Ddd.Domain;
+
+/// <summary>
+/// Base class for value objects. Value objects are immutable and compared by their values.
+/// Prefer using C# records for simple value objects.
+/// </summary>
+public abstract class ValueObject : IEquatable<ValueObject>
+{
+    protected abstract IEnumerable<object?> GetEqualityComponents();
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null || obj.GetType() != GetType()) return false;
+        return Equals((ValueObject)obj);
+    }
+
+    public bool Equals(ValueObject? other)
+    {
+        if (other is null) return false;
+        return GetEqualityComponents().SequenceEqual(other.GetEqualityComponents());
+    }
+
+    public override int GetHashCode()
+    {
+        return GetEqualityComponents()
+            .Select(x => x?.GetHashCode() ?? 0)
+            .Aggregate((x, y) => x ^ y);
+    }
+
+    public static bool operator ==(ValueObject? left, ValueObject? right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(ValueObject? left, ValueObject? right)
+    {
+        return !Equals(left, right);
+    }
+}

--- a/src/OpenTicket.Ddd/Infrastructure/IUnitOfWork.cs
+++ b/src/OpenTicket.Ddd/Infrastructure/IUnitOfWork.cs
@@ -1,0 +1,9 @@
+namespace OpenTicket.Ddd.Infrastructure;
+
+/// <summary>
+/// Unit of Work pattern interface. Coordinates the persistence of multiple aggregates.
+/// </summary>
+public interface IUnitOfWork
+{
+    Task<int> SaveChangesAsync(CancellationToken ct = default);
+}

--- a/src/OpenTicket.Ddd/OpenTicket.Ddd.csproj
+++ b/src/OpenTicket.Ddd/OpenTicket.Ddd.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ErrorOr" Version="2.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/OpenTicket.Domain.Shared/OpenTicket.Domain.Shared.csproj
+++ b/src/OpenTicket.Domain.Shared/OpenTicket.Domain.Shared.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenTicket.Ddd\OpenTicket.Ddd.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/OpenTicket.Domain/OpenTicket.Domain.csproj
+++ b/src/OpenTicket.Domain/OpenTicket.Domain.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenTicket.Ddd\OpenTicket.Ddd.csproj" />
+    <ProjectReference Include="..\OpenTicket.Domain.Shared\OpenTicket.Domain.Shared.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/OpenTicket.Infrastructure.Database/OpenTicket.Infrastructure.Database.csproj
+++ b/src/OpenTicket.Infrastructure.Database/OpenTicket.Infrastructure.Database.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenTicket.Application.Contracts\OpenTicket.Application.Contracts.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/OpenTicket.Infrastructure.Identity/OpenTicket.Infrastructure.Identity.csproj
+++ b/src/OpenTicket.Infrastructure.Identity/OpenTicket.Infrastructure.Identity.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenTicket.Application.Contracts\OpenTicket.Application.Contracts.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/OpenTicket.Infrastructure.MessageBroker/OpenTicket.Infrastructure.MessageBroker.csproj
+++ b/src/OpenTicket.Infrastructure.MessageBroker/OpenTicket.Infrastructure.MessageBroker.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenTicket.Application.Contracts\OpenTicket.Application.Contracts.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/OpenTicket.Infrastructure.Payment/OpenTicket.Infrastructure.Payment.csproj
+++ b/src/OpenTicket.Infrastructure.Payment/OpenTicket.Infrastructure.Payment.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenTicket.Application.Contracts\OpenTicket.Application.Contracts.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/OpenTicket.Infrastructure/OpenTicket.Infrastructure.csproj
+++ b/src/OpenTicket.Infrastructure/OpenTicket.Infrastructure.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenTicket.Application.Contracts\OpenTicket.Application.Contracts.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/OpenTicket.Application.Tests/OpenTicket.Application.Tests.csproj
+++ b/tests/OpenTicket.Application.Tests/OpenTicket.Application.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenTicket.Application\OpenTicket.Application.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/OpenTicket.Domain.Tests/OpenTicket.Domain.Tests.csproj
+++ b/tests/OpenTicket.Domain.Tests/OpenTicket.Domain.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenTicket.Domain\OpenTicket.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/OpenTicket.Infrastructure.Tests/OpenTicket.Infrastructure.Tests.csproj
+++ b/tests/OpenTicket.Infrastructure.Tests/OpenTicket.Infrastructure.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenTicket.Infrastructure\OpenTicket.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\OpenTicket.Infrastructure.Database\OpenTicket.Infrastructure.Database.csproj" />
+    <ProjectReference Include="..\..\src\OpenTicket.Infrastructure.Payment\OpenTicket.Infrastructure.Payment.csproj" />
+    <ProjectReference Include="..\..\src\OpenTicket.Infrastructure.Identity\OpenTicket.Infrastructure.Identity.csproj" />
+    <ProjectReference Include="..\..\src\OpenTicket.Infrastructure.MessageBroker\OpenTicket.Infrastructure.MessageBroker.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Add Clean Architecture solution structure with DDD base classes
- Configure project dependencies following dependency inversion principle
- Add ErrorOr package for Result pattern

## Projects Added
| Project | Purpose |
|---------|---------|
| `OpenTicket.Ddd` | Base classes (Entity, AggregateRoot, ValueObject, etc.) |
| `OpenTicket.Domain.Shared` | Shared enums, constants |
| `OpenTicket.Domain` | Business domain models |
| `OpenTicket.Application.Contracts` | Service interfaces, DTOs |
| `OpenTicket.Application` | Use cases implementation |
| `OpenTicket.Infrastructure.*` | Provider implementations |
| `OpenTicket.Api` | Entry point |

## Infrastructure Providers (folder structure ready)
- **Database**: InMemory, PostgreSQL, MongoDB
- **Payment**: Mock, Stripe, LinePay
- **Identity**: Mock, Google, GitHub, Apple
- **MessageBroker**: InMemory, NATS, RabbitMQ

## Test plan
- [x] `dotnet build` succeeds
- [x] Review project references are correct