### PR TITLE
feat(ticket): implement Seat aggregate root with lock/release/sell behaviors

### DIFF
--- a/src/OpenTicket.Ddd/Domain/IStronglyTypedId.cs
+++ b/src/OpenTicket.Ddd/Domain/IStronglyTypedId.cs
@@ -1,0 +1,11 @@
+namespace OpenTicket.Ddd.Domain;
+
+/// <summary>
+/// Interface for strongly typed identifiers.
+/// Prevents primitive obsession by wrapping identifiers in type-safe structs.
+/// </summary>
+/// <typeparam name="T">The underlying value type (usually Guid or string).</typeparam>
+public interface IStronglyTypedId<out T>
+{
+    T Value { get; }
+}

--- a/src/OpenTicket.Domain.Shared/Identities/AreaId.cs
+++ b/src/OpenTicket.Domain.Shared/Identities/AreaId.cs
@@ -1,0 +1,10 @@
+using OpenTicket.Ddd.Domain;
+
+namespace OpenTicket.Domain.Shared.Identities;
+
+public readonly record struct AreaId(Guid Value) : IStronglyTypedId<Guid>
+{
+    public static AreaId New() => new(Guid.NewGuid());
+    public static AreaId From(Guid value) => new(value);
+    public override string ToString() => Value.ToString();
+}

--- a/src/OpenTicket.Domain.Shared/Identities/OrderId.cs
+++ b/src/OpenTicket.Domain.Shared/Identities/OrderId.cs
@@ -1,0 +1,10 @@
+using OpenTicket.Ddd.Domain;
+
+namespace OpenTicket.Domain.Shared.Identities;
+
+public readonly record struct OrderId(Guid Value) : IStronglyTypedId<Guid>
+{
+    public static OrderId New() => new(Guid.NewGuid());
+    public static OrderId From(Guid value) => new(value);
+    public override string ToString() => Value.ToString();
+}

--- a/src/OpenTicket.Domain.Shared/Identities/SessionId.cs
+++ b/src/OpenTicket.Domain.Shared/Identities/SessionId.cs
@@ -1,0 +1,10 @@
+using OpenTicket.Ddd.Domain;
+
+namespace OpenTicket.Domain.Shared.Identities;
+
+public readonly record struct SessionId(Guid Value) : IStronglyTypedId<Guid>
+{
+    public static SessionId New() => new(Guid.NewGuid());
+    public static SessionId From(Guid value) => new(value);
+    public override string ToString() => Value.ToString();
+}

--- a/src/OpenTicket.Domain.Shared/Identities/UserId.cs
+++ b/src/OpenTicket.Domain.Shared/Identities/UserId.cs
@@ -1,0 +1,10 @@
+using OpenTicket.Ddd.Domain;
+
+namespace OpenTicket.Domain.Shared.Identities;
+
+public readonly record struct UserId(Guid Value) : IStronglyTypedId<Guid>
+{
+    public static UserId New() => new(Guid.NewGuid());
+    public static UserId From(Guid value) => new(value);
+    public override string ToString() => Value.ToString();
+}

--- a/src/OpenTicket.Domain.Shared/Tickets/Enums/SeatStatus.cs
+++ b/src/OpenTicket.Domain.Shared/Tickets/Enums/SeatStatus.cs
@@ -1,0 +1,8 @@
+namespace OpenTicket.Domain.Shared.Tickets.Enums;
+
+public enum SeatStatus
+{
+    Available = 0,
+    Locked = 1,
+    Sold = 2
+}

--- a/src/OpenTicket.Domain.Shared/Tickets/Events/SeatLockedEvent.cs
+++ b/src/OpenTicket.Domain.Shared/Tickets/Events/SeatLockedEvent.cs
@@ -1,0 +1,11 @@
+using OpenTicket.Ddd.Domain;
+using OpenTicket.Domain.Shared.Identities;
+
+namespace OpenTicket.Domain.Shared.Tickets.Events;
+
+public sealed record SeatLockedEvent(
+    SessionId SessionId,
+    AreaId AreaId,
+    string SeatNumber,
+    UserId LockedBy,
+    DateTime ExpiresAt) : DomainEvent;

--- a/src/OpenTicket.Domain.Shared/Tickets/Events/SeatReleasedEvent.cs
+++ b/src/OpenTicket.Domain.Shared/Tickets/Events/SeatReleasedEvent.cs
@@ -1,0 +1,9 @@
+using OpenTicket.Ddd.Domain;
+using OpenTicket.Domain.Shared.Identities;
+
+namespace OpenTicket.Domain.Shared.Tickets.Events;
+
+public sealed record SeatReleasedEvent(
+    SessionId SessionId,
+    AreaId AreaId,
+    string SeatNumber) : DomainEvent;

--- a/src/OpenTicket.Domain.Shared/Tickets/Events/SeatSoldEvent.cs
+++ b/src/OpenTicket.Domain.Shared/Tickets/Events/SeatSoldEvent.cs
@@ -1,0 +1,11 @@
+using OpenTicket.Ddd.Domain;
+using OpenTicket.Domain.Shared.Identities;
+
+namespace OpenTicket.Domain.Shared.Tickets.Events;
+
+public sealed record SeatSoldEvent(
+    SessionId SessionId,
+    AreaId AreaId,
+    string SeatNumber,
+    UserId BuyerId,
+    OrderId OrderId) : DomainEvent;

--- a/src/OpenTicket.Domain/Tickets/Entities/Seat.cs
+++ b/src/OpenTicket.Domain/Tickets/Entities/Seat.cs
@@ -1,0 +1,88 @@
+using ErrorOr;
+using OpenTicket.Ddd.Domain;
+using OpenTicket.Domain.Shared.Identities;
+using OpenTicket.Domain.Shared.Tickets.Enums;
+using OpenTicket.Domain.Shared.Tickets.Events;
+using OpenTicket.Domain.Tickets.ValueObjects;
+
+namespace OpenTicket.Domain.Tickets.Entities;
+
+public class Seat : AggregateRoot<SeatId>
+{
+    public SessionId SessionId { get; private set; }
+    public AreaId AreaId { get; private set; }
+    public string Number { get; private set; } = string.Empty;
+    public SeatStatus Status { get; private set; }
+    public UserId? LockedBy { get; private set; }
+    public DateTime? LockExpiresAt { get; private set; }
+    public OrderId? SoldToOrder { get; private set; }
+
+    private Seat() { } // EF Core
+
+    public static Seat Create(SessionId sessionId, AreaId areaId, string number)
+    {
+        var seat = new Seat
+        {
+            Id = SeatId.From(sessionId, areaId, number),
+            SessionId = sessionId,
+            AreaId = areaId,
+            Number = number,
+            Status = SeatStatus.Available
+        };
+        return seat;
+    }
+
+    public ErrorOr<Success> Lock(UserId userId, TimeSpan ttl)
+    {
+        if (Status != SeatStatus.Available)
+            return Error.Conflict("Seat.NotAvailable", "Seat is not available for locking");
+
+        LockedBy = userId;
+        LockExpiresAt = DateTime.UtcNow + ttl;
+        Status = SeatStatus.Locked;
+
+        AddDomainEvent(new SeatLockedEvent(SessionId, AreaId, Number, userId, LockExpiresAt.Value));
+
+        return Result.Success;
+    }
+
+    public void Release()
+    {
+        if (Status != SeatStatus.Locked)
+            return;
+
+        var wasLocked = Status == SeatStatus.Locked;
+        LockedBy = null;
+        LockExpiresAt = null;
+        Status = SeatStatus.Available;
+
+        if (wasLocked)
+            AddDomainEvent(new SeatReleasedEvent(SessionId, AreaId, Number));
+    }
+
+    public ErrorOr<Success> Sell(UserId buyerId, OrderId orderId)
+    {
+        if (Status != SeatStatus.Locked)
+            return Error.Conflict("Seat.NotLocked", "Seat must be locked before selling");
+
+        if (LockedBy != buyerId)
+            return Error.Conflict("Seat.NotLockedByUser", "Seat is locked by another user");
+
+        Status = SeatStatus.Sold;
+        SoldToOrder = orderId;
+        LockedBy = null;
+        LockExpiresAt = null;
+
+        AddDomainEvent(new SeatSoldEvent(SessionId, AreaId, Number, buyerId, orderId));
+
+        return Result.Success;
+    }
+
+    public bool IsLockExpired()
+    {
+        if (Status != SeatStatus.Locked || LockExpiresAt is null)
+            return false;
+
+        return DateTime.UtcNow > LockExpiresAt.Value;
+    }
+}

--- a/src/OpenTicket.Domain/Tickets/Repositories/ISeatRepository.cs
+++ b/src/OpenTicket.Domain/Tickets/Repositories/ISeatRepository.cs
@@ -1,0 +1,12 @@
+using OpenTicket.Ddd.Application;
+using OpenTicket.Domain.Shared.Identities;
+using OpenTicket.Domain.Tickets.Entities;
+using OpenTicket.Domain.Tickets.ValueObjects;
+
+namespace OpenTicket.Domain.Tickets.Repositories;
+
+public interface ISeatRepository : IRepository<Seat, SeatId>
+{
+    Task<IReadOnlyList<Seat>> GetBySessionAsync(SessionId sessionId, CancellationToken ct = default);
+    Task<IReadOnlyList<Seat>> GetBySessionAndAreaAsync(SessionId sessionId, AreaId areaId, CancellationToken ct = default);
+}

--- a/src/OpenTicket.Domain/Tickets/ValueObjects/SeatId.cs
+++ b/src/OpenTicket.Domain/Tickets/ValueObjects/SeatId.cs
@@ -1,0 +1,17 @@
+using OpenTicket.Ddd.Domain;
+using OpenTicket.Domain.Shared.Identities;
+
+namespace OpenTicket.Domain.Tickets.ValueObjects;
+
+public readonly record struct SeatId(
+    SessionId SessionId,
+    AreaId AreaId,
+    string Number) : IStronglyTypedId<string>
+{
+    public string Value => ToString();
+
+    public override string ToString() => $"{SessionId.Value}:{AreaId.Value}:{Number}";
+
+    public static SeatId From(SessionId sessionId, AreaId areaId, string number)
+        => new(sessionId, areaId, number);
+}

--- a/tests/OpenTicket.Application.Tests/OpenTicket.Application.Tests.csproj
+++ b/tests/OpenTicket.Application.Tests/OpenTicket.Application.Tests.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/tests/OpenTicket.Domain.Tests/OpenTicket.Domain.Tests.csproj
+++ b/tests/OpenTicket.Domain.Tests/OpenTicket.Domain.Tests.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/tests/OpenTicket.Domain.Tests/Tickets/SeatTests.cs
+++ b/tests/OpenTicket.Domain.Tests/Tickets/SeatTests.cs
@@ -1,0 +1,223 @@
+using OpenTicket.Domain.Shared.Identities;
+using OpenTicket.Domain.Shared.Tickets.Enums;
+using OpenTicket.Domain.Shared.Tickets.Events;
+using OpenTicket.Domain.Tickets.Entities;
+using Shouldly;
+
+namespace OpenTicket.Domain.Tests.Tickets;
+
+public class SeatTests
+{
+    private readonly SessionId _sessionId = SessionId.New();
+    private readonly AreaId _areaId = AreaId.New();
+    private readonly UserId _userId = UserId.New();
+    private const string SeatNumber = "A-001";
+
+    private Seat CreateSeat() => Seat.Create(_sessionId, _areaId, SeatNumber);
+
+    [Fact]
+    public void Create_ShouldReturnSeat_WithAvailableStatus()
+    {
+        // Act
+        var seat = CreateSeat();
+
+        // Assert
+        seat.SessionId.ShouldBe(_sessionId);
+        seat.AreaId.ShouldBe(_areaId);
+        seat.Number.ShouldBe(SeatNumber);
+        seat.Status.ShouldBe(SeatStatus.Available);
+        seat.LockedBy.ShouldBeNull();
+        seat.LockExpiresAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Lock_WhenAvailable_ShouldSucceed()
+    {
+        // Arrange
+        var seat = CreateSeat();
+        var ttl = TimeSpan.FromMinutes(2);
+
+        // Act
+        var result = seat.Lock(_userId, ttl);
+
+        // Assert
+        result.IsError.ShouldBeFalse();
+        seat.Status.ShouldBe(SeatStatus.Locked);
+        seat.LockedBy.ShouldBe(_userId);
+        seat.LockExpiresAt.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Lock_WhenAvailable_ShouldRaiseSeatLockedEvent()
+    {
+        // Arrange
+        var seat = CreateSeat();
+
+        // Act
+        seat.Lock(_userId, TimeSpan.FromMinutes(2));
+
+        // Assert
+        var domainEvent = seat.DomainEvents.ShouldHaveSingleItem();
+        var lockedEvent = domainEvent.ShouldBeOfType<SeatLockedEvent>();
+        lockedEvent.SessionId.ShouldBe(_sessionId);
+        lockedEvent.AreaId.ShouldBe(_areaId);
+        lockedEvent.SeatNumber.ShouldBe(SeatNumber);
+        lockedEvent.LockedBy.ShouldBe(_userId);
+    }
+
+    [Fact]
+    public void Lock_WhenAlreadyLocked_ShouldReturnError()
+    {
+        // Arrange
+        var seat = CreateSeat();
+        seat.Lock(_userId, TimeSpan.FromMinutes(2));
+        var anotherUser = UserId.New();
+
+        // Act
+        var result = seat.Lock(anotherUser, TimeSpan.FromMinutes(2));
+
+        // Assert
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Code.ShouldBe("Seat.NotAvailable");
+    }
+
+    [Fact]
+    public void Lock_WhenSold_ShouldReturnError()
+    {
+        // Arrange
+        var seat = CreateSeat();
+        seat.Lock(_userId, TimeSpan.FromMinutes(2));
+        seat.Sell(_userId, OrderId.New());
+
+        // Act
+        var result = seat.Lock(_userId, TimeSpan.FromMinutes(2));
+
+        // Assert
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Code.ShouldBe("Seat.NotAvailable");
+    }
+
+    [Fact]
+    public void Release_WhenLocked_ShouldSucceed()
+    {
+        // Arrange
+        var seat = CreateSeat();
+        seat.Lock(_userId, TimeSpan.FromMinutes(2));
+        seat.ClearDomainEvents();
+
+        // Act
+        seat.Release();
+
+        // Assert
+        seat.Status.ShouldBe(SeatStatus.Available);
+        seat.LockedBy.ShouldBeNull();
+        seat.LockExpiresAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Release_WhenLocked_ShouldRaiseSeatReleasedEvent()
+    {
+        // Arrange
+        var seat = CreateSeat();
+        seat.Lock(_userId, TimeSpan.FromMinutes(2));
+        seat.ClearDomainEvents();
+
+        // Act
+        seat.Release();
+
+        // Assert
+        var domainEvent = seat.DomainEvents.ShouldHaveSingleItem();
+        var releasedEvent = domainEvent.ShouldBeOfType<SeatReleasedEvent>();
+        releasedEvent.SessionId.ShouldBe(_sessionId);
+    }
+
+    [Fact]
+    public void Sell_WhenLockedBySameUser_ShouldSucceed()
+    {
+        // Arrange
+        var seat = CreateSeat();
+        var orderId = OrderId.New();
+        seat.Lock(_userId, TimeSpan.FromMinutes(2));
+        seat.ClearDomainEvents();
+
+        // Act
+        var result = seat.Sell(_userId, orderId);
+
+        // Assert
+        result.IsError.ShouldBeFalse();
+        seat.Status.ShouldBe(SeatStatus.Sold);
+        seat.SoldToOrder.ShouldBe(orderId);
+    }
+
+    [Fact]
+    public void Sell_WhenLockedBySameUser_ShouldRaiseSeatSoldEvent()
+    {
+        // Arrange
+        var seat = CreateSeat();
+        var orderId = OrderId.New();
+        seat.Lock(_userId, TimeSpan.FromMinutes(2));
+        seat.ClearDomainEvents();
+
+        // Act
+        seat.Sell(_userId, orderId);
+
+        // Assert
+        var domainEvent = seat.DomainEvents.ShouldHaveSingleItem();
+        var soldEvent = domainEvent.ShouldBeOfType<SeatSoldEvent>();
+        soldEvent.BuyerId.ShouldBe(_userId);
+        soldEvent.OrderId.ShouldBe(orderId);
+    }
+
+    [Fact]
+    public void Sell_WhenLockedByDifferentUser_ShouldReturnError()
+    {
+        // Arrange
+        var seat = CreateSeat();
+        seat.Lock(_userId, TimeSpan.FromMinutes(2));
+        var anotherUser = UserId.New();
+
+        // Act
+        var result = seat.Sell(anotherUser, OrderId.New());
+
+        // Assert
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Code.ShouldBe("Seat.NotLockedByUser");
+    }
+
+    [Fact]
+    public void Sell_WhenNotLocked_ShouldReturnError()
+    {
+        // Arrange
+        var seat = CreateSeat();
+
+        // Act
+        var result = seat.Sell(_userId, OrderId.New());
+
+        // Assert
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Code.ShouldBe("Seat.NotLocked");
+    }
+
+    [Fact]
+    public void IsLockExpired_WhenExpired_ShouldReturnTrue()
+    {
+        // Arrange
+        var seat = CreateSeat();
+        seat.Lock(_userId, TimeSpan.FromMilliseconds(1));
+        Thread.Sleep(10);
+
+        // Act & Assert
+        seat.IsLockExpired().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsLockExpired_WhenNotExpired_ShouldReturnFalse()
+    {
+        // Arrange
+        var seat = CreateSeat();
+        seat.Lock(_userId, TimeSpan.FromMinutes(2));
+
+        // Act & Assert
+        seat.IsLockExpired().ShouldBeFalse();
+    }
+}

--- a/tests/OpenTicket.Infrastructure.Tests/OpenTicket.Infrastructure.Tests.csproj
+++ b/tests/OpenTicket.Infrastructure.Tests/OpenTicket.Infrastructure.Tests.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Implement Seat as AggregateRoot with Lock, Release, Sell behaviors for zero double-sell guarantee
- Add Strongly Typed IDs (SessionId, AreaId, UserId, OrderId) with IStronglyTypedId interface
- Add domain events: SeatLockedEvent, SeatReleasedEvent, SeatSoldEvent
- Update testing conventions to use NSubstitute + Shouldly

## Changes
- `src/OpenTicket.Ddd/Domain/IStronglyTypedId.cs` - Type-safe identifier interface
- `src/OpenTicket.Domain.Shared/Identities/` - SessionId, AreaId, UserId, OrderId
- `src/OpenTicket.Domain.Shared/Tickets/` - SeatStatus enum, domain events
- `src/OpenTicket.Domain/Tickets/` - Seat entity, SeatId value object, ISeatRepository
- `tests/OpenTicket.Domain.Tests/Tickets/SeatTests.cs` - 13 unit tests
- `CLAUDE.md` - Added NSubstitute + Shouldly testing conventions

## Test plan
- [x] All 13 Seat unit tests pass
- [x] Tests cover: Create, Lock, Release, Sell, lock expiration scenarios
- [x] Domain events properly raised for each state change