### PR TITLE
feat(identity): implement identity and authorization module

### DIFF
--- a/docs/sdk/AUTH.md
+++ b/docs/sdk/AUTH.md
@@ -1,0 +1,809 @@
+# OpenTicket Auth SDK
+
+**Version:** 1.0
+**Last Updated:** 2025-01
+
+---
+
+## 1. Overview
+
+OpenTicket Auth SDK provides a comprehensive authentication and authorization framework with:
+
+- **Authentication**: Identity management with OAuth providers (Google, Facebook, GitHub, Apple)
+- **Authorization**: Resource-based access control for domain entities
+- **Rate Limiting**: Action-based quotas with subscription tiers
+- **JWT Token**: Secure token generation and validation
+
+```
+┌────────────────────────────────────────────────────────────────────────────────────┐
+│                                       Auth Architecture                            │
+├────────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                    │
+│  ┌────────────────────────────┐    ┌──────────────────┐    ┌─────────────────┐     │
+│  │       API Controller       │───▶│   ICurrentUser   │◀───│  JWT Provider   │     │
+│  │                            │    │     Provider     │    │  (HttpContext)  │     │
+│  └────────────────────────────┘    └──────────────────┘    └─────────────────┘     │
+│                │                            │                       │              │
+│                ▼                            ▼                       ▼              │
+│  ┌────────────────────────────┐    ┌──────────────────┐    ┌─────────────────┐     │
+│  │   IAuthorizationService    │    │  IRateLimitSvc   │    │ ITokenService   │     │
+│  └────────────────────────────┘    └──────────────────┘    └─────────────────┘     │
+│                │                            │                       │              │
+│                ▼                            ▼                       ▼              │
+│  ┌────────────────────────────────────────────────────────────────────────────┐    │
+│  │                                   Domain Resources                         │    │
+│  │                    Note.CanRead()  Note.CanModify()  SharedWith[]          │    │
+│  └────────────────────────────────────────────────────────────────────────────┘    │
+│                                                                                    │
+└────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. Quick Start
+
+### 2.1 Service Registration
+
+```csharp
+// Program.cs or Module
+public static IServiceCollection AddOpenTicketAuth(
+    this IServiceCollection services,
+    IConfiguration configuration)
+{
+    // Option 1: Mock Identity (MVP/Testing)
+    services.AddIdentity(IdentityProvider.Mock);
+
+    // Option 2: OAuth Identity (Production)
+    services.AddOAuthIdentity(configuration);
+
+    // Authorization & Rate Limiting (auto-registered via Application module)
+    services.AddOpenTicketApplication();
+
+    return services;
+}
+```
+
+### 2.2 Configuration
+
+```json
+// appsettings.json
+{
+  "OAuth": {
+    "Jwt": {
+      "Secret": "your-256-bit-secret-key-here-minimum-32-chars",
+      "Issuer": "OpenTicket",
+      "Audience": "OpenTicket.Api",
+      "ExpirationMinutes": 60
+    },
+    "Google": {
+      "ClientId": "your-google-client-id",
+      "ClientSecret": "your-google-client-secret"
+    },
+    "Facebook": {
+      "ClientId": "your-facebook-app-id",
+      "ClientSecret": "your-facebook-app-secret"
+    },
+    "GitHub": {
+      "ClientId": "your-github-client-id",
+      "ClientSecret": "your-github-client-secret"
+    },
+    "Apple": {
+      "ClientId": "your-apple-service-id",
+      "TeamId": "your-apple-team-id",
+      "KeyId": "your-apple-key-id",
+      "PrivateKey": "-----BEGIN PRIVATE KEY-----..."
+    }
+  }
+}
+```
+
+---
+
+## 3. Core Abstractions
+
+### 3.1 CurrentUser
+
+Represents the authenticated user in the current request context.
+
+```csharp
+namespace OpenTicket.Application.Contracts.Identity;
+
+public class CurrentUser
+{
+    /// <summary>
+    /// Unique user identifier (strongly typed).
+    /// </summary>
+    public UserId Id { get; init; }
+
+    /// <summary>
+    /// User's email address.
+    /// </summary>
+    public string Email { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Display name.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Assigned roles (e.g., "Admin", "User").
+    /// </summary>
+    public IReadOnlyList<string> Roles { get; init; } = [];
+
+    /// <summary>
+    /// Whether the user is authenticated.
+    /// </summary>
+    public bool IsAuthenticated { get; init; }
+
+    /// <summary>
+    /// Whether the user has an active subscription.
+    /// </summary>
+    public bool HasSubscription { get; init; }
+
+    // Helper methods
+    public bool IsInRole(string role) =>
+        Roles.Contains(role, StringComparer.OrdinalIgnoreCase);
+
+    public bool IsAdmin => IsInRole("Admin");
+}
+```
+
+### 3.2 Roles
+
+Standard role constants used throughout the application.
+
+```csharp
+namespace OpenTicket.Application.Contracts.Identity;
+
+public static class Roles
+{
+    /// <summary>
+    /// Administrator with full system access.
+    /// </summary>
+    public const string Admin = "Admin";
+
+    /// <summary>
+    /// Regular authenticated user.
+    /// </summary>
+    public const string User = "User";
+}
+```
+
+### 3.3 ICurrentUserProvider
+
+Interface to access the current user from any service.
+
+```csharp
+namespace OpenTicket.Application.Contracts.Identity;
+
+public interface ICurrentUserProvider
+{
+    /// <summary>
+    /// Gets the current authenticated user.
+    /// </summary>
+    CurrentUser CurrentUser { get; }
+}
+```
+
+---
+
+## 4. Authorization Service
+
+### 4.1 IAuthorizationService
+
+Resource-based authorization for domain entities.
+
+```csharp
+namespace OpenTicket.Application.Contracts.Authorization;
+
+public interface IAuthorizationService
+{
+    /// <summary>
+    /// Authorize an action on a resource.
+    /// </summary>
+    Task<ErrorOr<Success>> AuthorizeAsync<TResource>(
+        TResource resource,
+        ResourceAction action,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Current authenticated user.
+    /// </summary>
+    CurrentUser CurrentUser { get; }
+
+    /// <summary>
+    /// Whether current user is admin.
+    /// </summary>
+    bool IsAdmin { get; }
+}
+
+public enum ResourceAction
+{
+    Read,
+    Create,
+    Update,
+    Delete
+}
+```
+
+### 4.2 Usage in Handlers
+
+```csharp
+public sealed class UpdateNoteCommandHandler
+    : ICommandHandler<UpdateNoteCommand, ErrorOr<Updated>>
+{
+    private readonly IRepository<Note> _noteRepository;
+    private readonly IAuthorizationService _authorizationService;
+
+    public async Task<ErrorOr<Updated>> HandleAsync(
+        UpdateNoteCommand command,
+        CancellationToken ct = default)
+    {
+        var note = await _noteRepository.FindAsync(command.Id, ct);
+
+        if (note is null)
+            return Error.NotFound("Note.NotFound", "Note not found.");
+
+        // Check authorization
+        var authResult = await _authorizationService.AuthorizeAsync(
+            note,
+            ResourceAction.Update,
+            ct);
+
+        if (authResult.IsError)
+            return authResult.Errors;
+
+        // Proceed with update...
+        note.Update(command.Title, command.Body);
+        await _noteRepository.UpdateAsync(note, ct);
+
+        return Result.Updated;
+    }
+}
+```
+
+### 4.3 Authorization Rules
+
+| Resource | Action | Rule |
+|----------|--------|------|
+| Note | Read | Creator OR SharedWith OR Admin |
+| Note | Create | Any authenticated user |
+| Note | Update | Creator OR Admin |
+| Note | Delete | Creator OR Admin |
+
+### 4.4 Domain Model Integration
+
+Add access control methods to domain entities:
+
+```csharp
+public class Note : Entity<Guid>
+{
+    public UserId CreatorId { get; private set; }
+
+    private readonly List<UserId> _sharedWith = [];
+    public IReadOnlyList<UserId> SharedWith => _sharedWith.AsReadOnly();
+
+    /// <summary>
+    /// Check if user can read this note.
+    /// </summary>
+    public bool CanRead(UserId userId)
+    {
+        return CreatorId == userId || IsSharedWith(userId);
+    }
+
+    /// <summary>
+    /// Check if user can modify this note.
+    /// </summary>
+    public bool CanModify(UserId userId)
+    {
+        return CreatorId == userId;
+    }
+
+    /// <summary>
+    /// Share note with another user.
+    /// </summary>
+    public void ShareWith(UserId userId)
+    {
+        if (!IsSharedWith(userId) && userId != CreatorId)
+        {
+            _sharedWith.Add(userId);
+            UpdatedAt = DateTime.UtcNow;
+        }
+    }
+
+    /// <summary>
+    /// Revoke share access.
+    /// </summary>
+    public void RevokeShare(UserId userId)
+    {
+        _sharedWith.Remove(userId);
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    private bool IsSharedWith(UserId userId) =>
+        _sharedWith.Contains(userId);
+}
+```
+
+---
+
+## 5. Rate Limiting Service
+
+### 5.1 IRateLimitService
+
+Action-based quota enforcement.
+
+```csharp
+namespace OpenTicket.Application.Contracts.RateLimiting;
+
+public interface IRateLimitService
+{
+    /// <summary>
+    /// Check if action is allowed under rate limit.
+    /// </summary>
+    Task<ErrorOr<Success>> CheckRateLimitAsync(
+        UserId userId,
+        RateLimitedAction action,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Record an action for rate limit tracking.
+    /// </summary>
+    Task RecordActionAsync(
+        UserId userId,
+        RateLimitedAction action,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Get remaining quota for an action.
+    /// </summary>
+    Task<int> GetRemainingQuotaAsync(
+        UserId userId,
+        RateLimitedAction action,
+        CancellationToken ct = default);
+}
+
+public enum RateLimitedAction
+{
+    CreateNote
+}
+```
+
+### 5.2 Rate Limit Rules
+
+| User Type | CreateNote/Day |
+|-----------|----------------|
+| Non-subscriber | 3 |
+| Subscriber | Unlimited |
+| Admin | Unlimited |
+
+### 5.3 Usage in Handlers
+
+```csharp
+public sealed class CreateNoteCommandHandler
+    : ICommandHandler<CreateNoteCommand, ErrorOr<CreateNoteCommandResult>>
+{
+    private readonly IRepository<Note> _noteRepository;
+    private readonly ICurrentUserProvider _currentUserProvider;
+    private readonly IRateLimitService _rateLimitService;
+
+    public async Task<ErrorOr<CreateNoteCommandResult>> HandleAsync(
+        CreateNoteCommand command,
+        CancellationToken ct = default)
+    {
+        var currentUser = _currentUserProvider.CurrentUser;
+
+        // Check rate limit
+        var rateLimitResult = await _rateLimitService.CheckRateLimitAsync(
+            currentUser.Id,
+            RateLimitedAction.CreateNote,
+            ct);
+
+        if (rateLimitResult.IsError)
+            return rateLimitResult.Errors;
+
+        // Create note
+        var note = Note.Create(command.Title, command.Body, currentUser.Id);
+        await _noteRepository.InsertAsync(note, ct);
+
+        // Record action for rate limiting
+        await _rateLimitService.RecordActionAsync(
+            currentUser.Id,
+            RateLimitedAction.CreateNote,
+            ct);
+
+        return new CreateNoteCommandResult(note.Id);
+    }
+}
+```
+
+### 5.4 Rate Limit Implementation
+
+Uses distributed cache for quota tracking:
+
+```csharp
+public sealed class RateLimitService : IRateLimitService
+{
+    private readonly IDistributedCache _cache;
+    private readonly ICurrentUserProvider _currentUserProvider;
+
+    private const int NonSubscriberDailyNoteLimit = 3;
+
+    public async Task<ErrorOr<Success>> CheckRateLimitAsync(
+        UserId userId,
+        RateLimitedAction action,
+        CancellationToken ct = default)
+    {
+        var currentUser = _currentUserProvider.CurrentUser;
+
+        // Bypass for admin and subscribers
+        if (currentUser.IsAdmin || currentUser.HasSubscription)
+            return Result.Success;
+
+        var limit = GetLimit(action);
+        if (limit < 0) // Unlimited
+            return Result.Success;
+
+        var key = GetRateLimitKey(userId, action);
+        var count = await _cache.GetAsync<int?>(key, ct) ?? 0;
+
+        if (count >= limit)
+        {
+            return Error.Forbidden(
+                "RateLimit.Exceeded",
+                $"Rate limit exceeded. Daily limit: {limit}.");
+        }
+
+        return Result.Success;
+    }
+
+    private static string GetRateLimitKey(UserId userId, RateLimitedAction action)
+    {
+        var today = DateTime.UtcNow.ToString("yyyy-MM-dd");
+        return $"ratelimit:{action}:{userId.Value}:{today}";
+    }
+}
+```
+
+---
+
+## 6. OAuth / JWT Authentication
+
+### 6.1 ITokenService
+
+JWT token generation for authenticated users.
+
+```csharp
+namespace OpenTicket.Application.Contracts.Identity;
+
+public interface ITokenService
+{
+    /// <summary>
+    /// Generate JWT token for user.
+    /// </summary>
+    string GenerateToken(CurrentUser user);
+
+    /// <summary>
+    /// Validate and parse JWT token.
+    /// </summary>
+    CurrentUser? ValidateToken(string token);
+}
+```
+
+### 6.2 JWT Token Structure
+
+```json
+{
+  "sub": "user-guid",
+  "email": "user@example.com",
+  "name": "John Doe",
+  "roles": ["User"],
+  "has_subscription": true,
+  "iat": 1735344000,
+  "exp": 1735347600,
+  "iss": "OpenTicket",
+  "aud": "OpenTicket.Api"
+}
+```
+
+### 6.3 OAuth Flow
+
+```
+┌─────────┐     ┌─────────────┐     ┌──────────────┐     ┌─────────┐
+│ Client  │────▶│ /auth/login │────▶│ OAuth        │────▶│ Google  │
+│         │     │ /{provider} │     │ Redirect     │     │ FB/etc  │
+└─────────┘     └─────────────┘     └──────────────┘     └─────────┘
+                                                               │
+     ┌─────────────────────────────────────────────────────────┘
+     │
+     ▼
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│ /auth/      │────▶│ Validate    │────▶│ Generate    │
+│ callback    │     │ OAuth Token │     │ JWT Token   │
+└─────────────┘     └─────────────┘     └─────────────┘
+                                               │
+                                               ▼
+                                        ┌─────────────┐
+                                        │ Return JWT  │
+                                        │ to Client   │
+                                        └─────────────┘
+```
+
+### 6.4 JwtCurrentUserProvider
+
+Extracts user from HTTP context JWT claims:
+
+```csharp
+public class JwtCurrentUserProvider : ICurrentUserProvider
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CurrentUser CurrentUser
+    {
+        get
+        {
+            var httpContext = _httpContextAccessor.HttpContext;
+            if (httpContext?.User.Identity?.IsAuthenticated != true)
+            {
+                return new CurrentUser { IsAuthenticated = false };
+            }
+
+            var claims = httpContext.User.Claims.ToList();
+
+            return new CurrentUser
+            {
+                Id = UserId.From(Guid.Parse(
+                    claims.First(c => c.Type == ClaimTypes.NameIdentifier).Value)),
+                Email = claims.FirstOrDefault(c => c.Type == ClaimTypes.Email)?.Value
+                    ?? string.Empty,
+                Name = claims.FirstOrDefault(c => c.Type == ClaimTypes.Name)?.Value
+                    ?? string.Empty,
+                Roles = claims
+                    .Where(c => c.Type == ClaimTypes.Role)
+                    .Select(c => c.Value)
+                    .ToList(),
+                HasSubscription = bool.TryParse(
+                    claims.FirstOrDefault(c => c.Type == "has_subscription")?.Value,
+                    out var sub) && sub,
+                IsAuthenticated = true
+            };
+        }
+    }
+}
+```
+
+---
+
+## 7. Identity Provider Setup
+
+### 7.1 Mock Provider (MVP/Testing)
+
+```csharp
+// Registration
+services.Configure<MockUserOptions>(opt =>
+{
+    opt.UserId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    opt.Email = "test@openticket.local";
+    opt.Name = "Test User";
+    opt.Roles = ["User"];
+    opt.HasSubscription = false;
+});
+services.AddScoped<ICurrentUserProvider, MockCurrentUserProvider>();
+```
+
+### 7.2 OAuth Provider (Production)
+
+```csharp
+// Registration
+services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = configuration["OAuth:Jwt:Issuer"],
+            ValidAudience = configuration["OAuth:Jwt:Audience"],
+            IssuerSigningKey = new SymmetricSecurityKey(
+                Encoding.UTF8.GetBytes(configuration["OAuth:Jwt:Secret"]!))
+        };
+    });
+
+services.AddScoped<ICurrentUserProvider, JwtCurrentUserProvider>();
+services.AddScoped<ITokenService, JwtTokenService>();
+```
+
+---
+
+## 8. API Controller Integration
+
+### 8.1 Controller with ErrorOr Handling
+
+```csharp
+[ApiController]
+[Route("api/[controller]")]
+[Authorize] // Requires authentication
+public class NoteController : ApiController
+{
+    private readonly IDispatcher _dispatcher;
+
+    [HttpPost]
+    [ProducesResponseType(typeof(CreateNoteCommandResult), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Create(
+        [FromBody] CreateNoteRequest request,
+        CancellationToken ct)
+    {
+        var result = await _dispatcher.SendAsync(
+            new CreateNoteCommand(request.Title, request.Body),
+            ct);
+
+        return result.Match(
+            success => CreatedAtAction(
+                nameof(GetById),
+                new { id = success.Id },
+                success),
+            errors => Problem(errors));
+    }
+
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Update(
+        Guid id,
+        [FromBody] UpdateNoteRequest request,
+        CancellationToken ct)
+    {
+        var result = await _dispatcher.SendAsync(
+            new UpdateNoteCommand(id, request.Title, request.Body),
+            ct);
+
+        return result.Match(
+            _ => NoContent(),
+            errors => Problem(errors));
+    }
+}
+```
+
+### 8.2 Error Response Format
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.3",
+  "title": "Forbidden",
+  "status": 403,
+  "errors": {
+    "Authorization": ["Note.ModifyDenied: Only the creator can modify this note."]
+  }
+}
+```
+
+---
+
+## 9. Testing
+
+### 9.1 Authorization Service Tests
+
+```csharp
+public class AuthorizationServiceTests
+{
+    private readonly ICurrentUserProvider _currentUserProvider;
+    private readonly AuthorizationService _sut;
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenAdmin_AlwaysAllowsAccess()
+    {
+        // Arrange
+        var adminUser = CreateUser(isAdmin: true);
+        _currentUserProvider.CurrentUser.Returns(adminUser);
+
+        var note = Note.Create("Test", "Body", UserId.New());
+
+        // Act
+        var result = await _sut.AuthorizeAsync(note, ResourceAction.Delete);
+
+        // Assert
+        result.IsError.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenSharedUser_CanOnlyRead()
+    {
+        // Arrange
+        var sharedUserId = UserId.New();
+        var user = CreateUser(sharedUserId);
+        _currentUserProvider.CurrentUser.Returns(user);
+
+        var note = Note.Create("Test", "Body", UserId.New());
+        note.ShareWith(sharedUserId);
+
+        // Act
+        var readResult = await _sut.AuthorizeAsync(note, ResourceAction.Read);
+        var updateResult = await _sut.AuthorizeAsync(note, ResourceAction.Update);
+
+        // Assert
+        readResult.IsError.ShouldBeFalse();
+        updateResult.IsError.ShouldBeTrue();
+        updateResult.FirstError.Code.ShouldBe("Note.ModifyDenied");
+    }
+}
+```
+
+### 9.2 Rate Limit Service Tests
+
+```csharp
+public class RateLimitServiceTests
+{
+    [Fact]
+    public async Task CheckRateLimitAsync_WhenSubscriber_AlwaysAllows()
+    {
+        // Arrange
+        var subscriberUser = CreateUser(hasSubscription: true);
+        _currentUserProvider.CurrentUser.Returns(subscriberUser);
+
+        // Act
+        var result = await _sut.CheckRateLimitAsync(
+            subscriberUser.Id,
+            RateLimitedAction.CreateNote);
+
+        // Assert
+        result.IsError.ShouldBeFalse();
+        // Cache should not be accessed
+        await _cache.DidNotReceive().GetAsync<int?>(
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CheckRateLimitAsync_WhenNonSubscriberAtLimit_DeniesAccess()
+    {
+        // Arrange
+        var user = CreateUser();
+        _currentUserProvider.CurrentUser.Returns(user);
+        _cache.GetAsync<int?>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(3); // At limit
+
+        // Act
+        var result = await _sut.CheckRateLimitAsync(
+            user.Id,
+            RateLimitedAction.CreateNote);
+
+        // Assert
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Code.ShouldBe("RateLimit.Exceeded");
+    }
+}
+```
+
+---
+
+## 10. Summary
+
+### 10.1 Component Matrix
+
+| Component | Abstraction | Implementation | Layer |
+|-----------|-------------|----------------|-------|
+| Current User | `ICurrentUserProvider` | `MockCurrentUserProvider`, `JwtCurrentUserProvider` | Infrastructure.Identity |
+| Authorization | `IAuthorizationService` | `AuthorizationService` | Application |
+| Rate Limiting | `IRateLimitService` | `RateLimitService` | Application |
+| Token Service | `ITokenService` | `JwtTokenService` | Infrastructure.Identity |
+
+### 10.2 Error Codes
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `Authorization.Unauthenticated` | 401 | User not authenticated |
+| `Note.AccessDenied` | 403 | No read permission |
+| `Note.ModifyDenied` | 403 | No modify permission |
+| `RateLimit.Exceeded` | 403 | Daily quota exceeded |
+
+### 10.3 Best Practices
+
+1. **Always use ErrorOr**: Return `ErrorOr<T>` from handlers for consistent error handling
+2. **Check authorization after fetch**: Load resource first, then check permissions
+3. **Record rate limit after success**: Only count actions that succeed
+4. **Domain owns access rules**: `CanRead()`, `CanModify()` belong in domain entities
+5. **Inject ICurrentUserProvider**: Don't pass user ID through all layers

--- a/src/OpenTicket.Api/Controllers/AuthController.cs
+++ b/src/OpenTicket.Api/Controllers/AuthController.cs
@@ -1,0 +1,209 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OpenTicket.Application.Contracts.Identity;
+using OpenTicket.Infrastructure.Identity.OAuth;
+
+namespace OpenTicket.Api.Controllers;
+
+/// <summary>
+/// Authentication endpoints for OAuth login and token management.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    private readonly ITokenService? _tokenService;
+    private readonly ICurrentUserProvider _currentUserProvider;
+    private readonly EnabledOAuthProviders? _enabledProviders;
+
+    public AuthController(
+        ICurrentUserProvider currentUserProvider,
+        ITokenService? tokenService = null,
+        EnabledOAuthProviders? enabledProviders = null)
+    {
+        _currentUserProvider = currentUserProvider;
+        _tokenService = tokenService;
+        _enabledProviders = enabledProviders;
+    }
+
+    /// <summary>
+    /// Get available OAuth providers.
+    /// </summary>
+    [HttpGet("providers")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(ProvidersResponse), StatusCodes.Status200OK)]
+    public IActionResult GetProviders()
+    {
+        var providers = _enabledProviders?.GetProviderNames() ?? [];
+        return Ok(new ProvidersResponse(providers));
+    }
+
+    /// <summary>
+    /// Initiate OAuth login flow.
+    /// Redirects to the OAuth provider's authorization page.
+    /// </summary>
+    /// <param name="provider">OAuth provider name (Google, Facebook, GitHub, Microsoft, Apple)</param>
+    /// <param name="returnUrl">URL to redirect after successful authentication</param>
+    [HttpGet("login/{provider}")]
+    [AllowAnonymous]
+    [ProducesResponseType(StatusCodes.Status302Found)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public IActionResult Login(string provider, [FromQuery] string? returnUrl = null)
+    {
+        if (_enabledProviders is null)
+        {
+            return BadRequest(new { error = "OAuth is not configured. Using mock authentication." });
+        }
+
+        var normalizedProvider = NormalizeProviderName(provider);
+        if (string.IsNullOrEmpty(normalizedProvider))
+        {
+            return BadRequest(new { error = $"Unknown provider: {provider}" });
+        }
+
+        var properties = new AuthenticationProperties
+        {
+            RedirectUri = Url.Action(nameof(Callback), new { returnUrl }),
+            Items = { { "provider", normalizedProvider } }
+        };
+
+        return Challenge(properties, normalizedProvider);
+    }
+
+    /// <summary>
+    /// OAuth callback endpoint.
+    /// Processes the OAuth response and issues a JWT token.
+    /// </summary>
+    [HttpGet("callback")]
+    [AllowAnonymous]
+    [ApiExplorerSettings(IgnoreApi = true)]
+    public async Task<IActionResult> Callback([FromQuery] string? returnUrl = null)
+    {
+        var authenticateResult = await HttpContext.AuthenticateAsync("External");
+
+        if (!authenticateResult.Succeeded || authenticateResult.Principal is null)
+        {
+            return Unauthorized(new { error = "OAuth authentication failed" });
+        }
+
+        if (_tokenService is null)
+        {
+            return BadRequest(new { error = "Token service not configured" });
+        }
+
+        // Extract user info from OAuth claims
+        var claims = authenticateResult.Principal.Claims.ToList();
+        var userId = claims.FirstOrDefault(c => c.Type == "sub")?.Value
+                  ?? claims.FirstOrDefault(c => c.Type == System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                  ?? Guid.NewGuid().ToString();
+
+        var email = claims.FirstOrDefault(c => c.Type == System.Security.Claims.ClaimTypes.Email)?.Value ?? "";
+        var name = claims.FirstOrDefault(c => c.Type == System.Security.Claims.ClaimTypes.Name)?.Value ?? "";
+        var provider = authenticateResult.Properties?.Items["provider"] ?? "OAuth";
+
+        // Create CurrentUser and generate JWT
+        var currentUser = new CurrentUser
+        {
+            Id = OpenTicket.Domain.Shared.Identities.UserId.From(Guid.TryParse(userId, out var uid) ? uid : Guid.NewGuid()),
+            Email = email,
+            Name = name,
+            Provider = provider,
+            Roles = [Roles.User],
+            IsAuthenticated = true,
+            HasSubscription = false
+        };
+
+        var token = _tokenService.GenerateAccessToken(currentUser);
+        var expiresAt = _tokenService.GetAccessTokenExpiration();
+
+        // Clear external cookie
+        await HttpContext.SignOutAsync("External");
+
+        // Return token or redirect
+        if (!string.IsNullOrEmpty(returnUrl))
+        {
+            var separator = returnUrl.Contains('?') ? "&" : "?";
+            return Redirect($"{returnUrl}{separator}token={token}");
+        }
+
+        return Ok(new AuthTokenResponse(token, "Bearer", (int)(expiresAt - DateTime.UtcNow).TotalSeconds));
+    }
+
+    /// <summary>
+    /// Get current user information.
+    /// </summary>
+    [HttpGet("me")]
+    [Authorize]
+    [ProducesResponseType(typeof(CurrentUserResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public IActionResult GetCurrentUser()
+    {
+        var user = _currentUserProvider.CurrentUser;
+
+        if (!user.IsAuthenticated)
+        {
+            return Unauthorized();
+        }
+
+        return Ok(new CurrentUserResponse(
+            user.Id.Value,
+            user.Email,
+            user.Name,
+            user.Provider,
+            user.Roles.ToList(),
+            user.HasSubscription,
+            user.IsAdmin));
+    }
+
+    /// <summary>
+    /// Refresh JWT token.
+    /// </summary>
+    [HttpPost("refresh")]
+    [Authorize]
+    [ProducesResponseType(typeof(AuthTokenResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public IActionResult RefreshToken()
+    {
+        if (_tokenService is null)
+        {
+            return BadRequest(new { error = "Token service not configured" });
+        }
+
+        var user = _currentUserProvider.CurrentUser;
+
+        if (!user.IsAuthenticated)
+        {
+            return Unauthorized();
+        }
+
+        var token = _tokenService.GenerateAccessToken(user);
+        var expiresAt = _tokenService.GetAccessTokenExpiration();
+        return Ok(new AuthTokenResponse(token, "Bearer", (int)(expiresAt - DateTime.UtcNow).TotalSeconds));
+    }
+
+    private static string? NormalizeProviderName(string provider)
+    {
+        return provider.ToLowerInvariant() switch
+        {
+            "google" => "Google",
+            "facebook" => "Facebook",
+            "github" => "GitHub",
+            "microsoft" => "Microsoft",
+            "apple" => "Apple",
+            _ => null
+        };
+    }
+}
+
+// Response DTOs
+public record ProvidersResponse(IReadOnlyList<string> Providers);
+public record AuthTokenResponse(string AccessToken, string TokenType, int ExpiresIn);
+public record CurrentUserResponse(
+    Guid Id,
+    string Email,
+    string Name,
+    string? Provider,
+    List<string> Roles,
+    bool HasSubscription,
+    bool IsAdmin);

--- a/src/OpenTicket.Api/Controllers/NoteController.cs
+++ b/src/OpenTicket.Api/Controllers/NoteController.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenTicket.Api.Models.Notes;
 using OpenTicket.Application.Contracts.Notes.Commands;
@@ -11,7 +10,6 @@ namespace OpenTicket.Api.Controllers;
 /// <summary>
 /// Manages notes - a simple CQRS example.
 /// </summary>
-[AllowAnonymous] // TODO: Remove after implementing authentication (Issue #5)
 [Produces("application/json")]
 public class NoteController : ApiController
 {
@@ -43,18 +41,19 @@ public class NoteController : ApiController
     [HttpGet("{id:guid}")]
     [ProducesResponseType(typeof(NoteDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
     {
         var result = await _dispatcher.QueryAsync(new GetNoteQuery(id), ct);
 
-        if (result is null)
-            return NotFound();
-
-        return Ok(result);
+        return result.Match(
+            note => Ok(note),
+            errors => Problem(errors));
     }
 
     /// <summary>
     /// Create a new note.
+    /// Non-subscribers are limited to 3 notes per day.
     /// </summary>
     /// <param name="request">The note creation request.</param>
     /// <param name="ct">Cancellation token.</param>
@@ -62,14 +61,19 @@ public class NoteController : ApiController
     [HttpPost]
     [ProducesResponseType(typeof(CreateNoteCommandResult), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Create([FromBody] CreateNoteRequest request, CancellationToken ct)
     {
         var result = await _dispatcher.SendAsync(new CreateNoteCommand(request.Title, request.Body), ct);
-        return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
+
+        return result.Match(
+            success => CreatedAtAction(nameof(GetById), new { id = success.Id }, success),
+            errors => Problem(errors));
     }
 
     /// <summary>
     /// Update an existing note (full replacement).
+    /// Only the creator or admin can update.
     /// </summary>
     /// <param name="id">The note ID.</param>
     /// <param name="request">The note update request.</param>
@@ -79,19 +83,20 @@ public class NoteController : ApiController
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Update(Guid id, [FromBody] UpdateNoteRequest request, CancellationToken ct)
     {
-        var success = await _dispatcher.SendAsync(new UpdateNoteCommand(id, request.Title, request.Body), ct);
+        var result = await _dispatcher.SendAsync(new UpdateNoteCommand(id, request.Title, request.Body), ct);
 
-        if (!success)
-            return NotFound();
-
-        return NoContent();
+        return result.Match(
+            _ => NoContent(),
+            errors => Problem(errors));
     }
 
     /// <summary>
     /// Partially update a note.
     /// Only provided fields will be updated.
+    /// Only the creator or admin can update.
     /// </summary>
     /// <param name="id">The note ID.</param>
     /// <param name="request">The partial update request.</param>
@@ -101,18 +106,19 @@ public class NoteController : ApiController
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Patch(Guid id, [FromBody] PatchNoteRequest request, CancellationToken ct)
     {
-        var success = await _dispatcher.SendAsync(new PatchNoteCommand(id, request.Title, request.Body), ct);
+        var result = await _dispatcher.SendAsync(new PatchNoteCommand(id, request.Title, request.Body), ct);
 
-        if (!success)
-            return NotFound();
-
-        return NoContent();
+        return result.Match(
+            _ => NoContent(),
+            errors => Problem(errors));
     }
 
     /// <summary>
     /// Delete a note.
+    /// Only the creator or admin can delete.
     /// </summary>
     /// <param name="id">The note ID.</param>
     /// <param name="ct">Cancellation token.</param>
@@ -120,13 +126,13 @@ public class NoteController : ApiController
     [HttpDelete("{id:guid}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
     {
-        var success = await _dispatcher.SendAsync(new RemoveNoteCommand(id), ct);
+        var result = await _dispatcher.SendAsync(new RemoveNoteCommand(id), ct);
 
-        if (!success)
-            return NotFound();
-
-        return NoContent();
+        return result.Match(
+            _ => NoContent(),
+            errors => Problem(errors));
     }
 }

--- a/src/OpenTicket.Api/OpenTicket.Api.csproj
+++ b/src/OpenTicket.Api/OpenTicket.Api.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\OpenTicket.Application\OpenTicket.Application.csproj" />
     <ProjectReference Include="..\OpenTicket.Infrastructure\OpenTicket.Infrastructure.csproj" />
+    <ProjectReference Include="..\OpenTicket.Infrastructure.Cache\OpenTicket.Infrastructure.Cache.csproj" />
     <ProjectReference Include="..\OpenTicket.Infrastructure.Database\OpenTicket.Infrastructure.Database.csproj" />
     <ProjectReference Include="..\OpenTicket.Infrastructure.Payment\OpenTicket.Infrastructure.Payment.csproj" />
     <ProjectReference Include="..\OpenTicket.Infrastructure.Identity\OpenTicket.Infrastructure.Identity.csproj" />

--- a/src/OpenTicket.Api/OpenTicketApiModule.cs
+++ b/src/OpenTicket.Api/OpenTicketApiModule.cs
@@ -50,6 +50,11 @@ public static class OpenTicketApiModule
         }
 
         app.UseHttpsRedirection();
+
+        // Enable authentication and authorization middleware
+        app.UseAuthentication();
+        app.UseAuthorization();
+
         app.MapControllers();
 
         return app;

--- a/src/OpenTicket.Api/OpenTicketApiModule.cs
+++ b/src/OpenTicket.Api/OpenTicketApiModule.cs
@@ -1,5 +1,7 @@
 using OpenTicket.Api.Services;
 using OpenTicket.Application;
+using OpenTicket.Infrastructure.Cache;
+using OpenTicket.Infrastructure.Cache.Abstractions;
 using OpenTicket.Infrastructure.Database;
 using OpenTicket.Infrastructure.Identity;
 using OpenTicket.Infrastructure.MessageBroker;
@@ -25,6 +27,9 @@ public static class OpenTicketApiModule
 
         // Register Persistence (InMemory for MVP)
         services.AddPersistence(DatabaseOption.InMemory);
+
+        // Register Cache (InMemory for MVP, Redis/NATS KV for production)
+        services.AddCache(configuration, CacheProvider.InMemory);
 
         // Register Identity (Mock for MVP)
         services.AddMockIdentity(configuration);

--- a/src/OpenTicket.Api/OpenTicketApiModule.cs
+++ b/src/OpenTicket.Api/OpenTicketApiModule.cs
@@ -31,8 +31,8 @@ public static class OpenTicketApiModule
         // Register Cache (InMemory for MVP, Redis/NATS KV for production)
         services.AddCache(configuration, CacheProvider.InMemory);
 
-        // Register Identity (Mock for MVP)
-        services.AddMockIdentity(configuration);
+        // Register Identity (OAuth with JWT for production, Mock fallback for testing)
+        services.AddOAuthIdentity(configuration);
 
         // Register Message Broker (InMemory for MVP, NATS/Redis for production)
         services.AddMessageBroker(configuration, MessageBrokerOption.InMemory);

--- a/src/OpenTicket.Api/OpenTicketApiModule.cs
+++ b/src/OpenTicket.Api/OpenTicketApiModule.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.OpenApi.Models;
 using OpenTicket.Api.Services;
 using OpenTicket.Application;
 using OpenTicket.Infrastructure.Cache;
@@ -19,8 +21,40 @@ public static class OpenTicketApiModule
         // Add controllers
         services.AddControllers();
 
-        // Add OpenAPI/Swagger
-        services.AddOpenApi();
+        // Add OpenAPI/Swagger with JWT Bearer authentication
+        services.AddOpenApi(options =>
+        {
+            options.AddDocumentTransformer((document, context, cancellationToken) =>
+            {
+                // Add JWT Bearer security scheme
+                document.Components ??= new OpenApiComponents();
+                document.Components.SecuritySchemes["Bearer"] = new OpenApiSecurityScheme
+                {
+                    Type = SecuritySchemeType.Http,
+                    Scheme = JwtBearerDefaults.AuthenticationScheme,
+                    BearerFormat = "JWT",
+                    Description = "Enter your JWT token. You can get one by logging in via /api/auth/login/{provider}"
+                };
+
+                // Apply security requirement globally
+                document.SecurityRequirements.Add(new OpenApiSecurityRequirement
+                {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.SecurityScheme,
+                                Id = "Bearer"
+                            }
+                        },
+                        Array.Empty<string>()
+                    }
+                });
+
+                return Task.CompletedTask;
+            });
+        });
 
         // Register Application layer (CQRS, handlers, settings)
         services.AddApplication(configuration);

--- a/src/OpenTicket.Api/appsettings.Development.json
+++ b/src/OpenTicket.Api/appsettings.Development.json
@@ -15,8 +15,8 @@
     },
     "GitHub": {
       "Enabled": true,
-      "ClientId": "",
-      "ClientSecret": ""
+      "ClientId": "Ov23liNnwa4fQhtVKLdP",
+      "ClientSecret": "5fd5ce468840ce06e28c97d24ab4993655e6f2f8"
     },
     "Google": {
       "Enabled": false,

--- a/src/OpenTicket.Api/appsettings.Development.json
+++ b/src/OpenTicket.Api/appsettings.Development.json
@@ -5,6 +5,25 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "OAuth": {
+    "Jwt": {
+      "SecretKey": "OpenTicket-Development-Secret-Key-Min-32-Chars!!",
+      "Issuer": "OpenTicket",
+      "Audience": "OpenTicket",
+      "AccessTokenExpirationMinutes": 60,
+      "RefreshTokenExpirationDays": 7
+    },
+    "GitHub": {
+      "Enabled": true,
+      "ClientId": "",
+      "ClientSecret": ""
+    },
+    "Google": {
+      "Enabled": false,
+      "ClientId": "",
+      "ClientSecret": ""
+    }
+  },
   "MockUser": {
     "UserId": "00000000-0000-0000-0000-000000000001",
     "Email": "your-email@example.com",

--- a/src/OpenTicket.Application.Contracts/Authorization/IAuthorizationService.cs
+++ b/src/OpenTicket.Application.Contracts/Authorization/IAuthorizationService.cs
@@ -1,0 +1,43 @@
+using ErrorOr;
+using OpenTicket.Application.Contracts.Identity;
+
+namespace OpenTicket.Application.Contracts.Authorization;
+
+/// <summary>
+/// Service for handling authorization checks.
+/// </summary>
+public interface IAuthorizationService
+{
+    /// <summary>
+    /// Checks if the current user can perform an action on a resource.
+    /// </summary>
+    /// <param name="resource">The resource being accessed.</param>
+    /// <param name="action">The action being performed.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Success if authorized, or an error.</returns>
+    Task<ErrorOr<Success>> AuthorizeAsync<TResource>(
+        TResource resource,
+        ResourceAction action,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the current user.
+    /// </summary>
+    CurrentUser CurrentUser { get; }
+
+    /// <summary>
+    /// Checks if the current user is an admin.
+    /// </summary>
+    bool IsAdmin { get; }
+}
+
+/// <summary>
+/// Actions that can be performed on resources.
+/// </summary>
+public enum ResourceAction
+{
+    Read,
+    Create,
+    Update,
+    Delete
+}

--- a/src/OpenTicket.Application.Contracts/Identity/CurrentUser.cs
+++ b/src/OpenTicket.Application.Contracts/Identity/CurrentUser.cs
@@ -38,6 +38,22 @@ public record CurrentUser
     public IReadOnlyList<string> Roles { get; init; } = [];
 
     /// <summary>
+    /// Whether the user has an active subscription.
+    /// Subscribers have unlimited access to certain features.
+    /// </summary>
+    public bool HasSubscription { get; init; }
+
+    /// <summary>
+    /// Checks if the user has a specific role.
+    /// </summary>
+    public bool IsInRole(string role) => Roles.Contains(role, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Checks if the user is an admin.
+    /// </summary>
+    public bool IsAdmin => IsInRole(WellKnownRoles.Admin);
+
+    /// <summary>
     /// Creates an anonymous (unauthenticated) user.
     /// </summary>
     public static CurrentUser Anonymous => new()

--- a/src/OpenTicket.Application.Contracts/Identity/CurrentUser.cs
+++ b/src/OpenTicket.Application.Contracts/Identity/CurrentUser.cs
@@ -51,7 +51,7 @@ public record CurrentUser
     /// <summary>
     /// Checks if the user is an admin.
     /// </summary>
-    public bool IsAdmin => IsInRole(WellKnownRoles.Admin);
+    public bool IsAdmin => IsInRole(Identity.Roles.Admin);
 
     /// <summary>
     /// Creates an anonymous (unauthenticated) user.

--- a/src/OpenTicket.Application.Contracts/Identity/ITokenService.cs
+++ b/src/OpenTicket.Application.Contracts/Identity/ITokenService.cs
@@ -1,0 +1,30 @@
+namespace OpenTicket.Application.Contracts.Identity;
+
+/// <summary>
+/// Service for generating and validating JWT tokens.
+/// </summary>
+public interface ITokenService
+{
+    /// <summary>
+    /// Generates an access token for the user.
+    /// </summary>
+    string GenerateAccessToken(CurrentUser user);
+
+    /// <summary>
+    /// Generates a refresh token.
+    /// </summary>
+    string GenerateRefreshToken();
+
+    /// <summary>
+    /// Gets the token expiration time.
+    /// </summary>
+    DateTime GetAccessTokenExpiration();
+}
+
+/// <summary>
+/// Token response containing access and refresh tokens.
+/// </summary>
+public record TokenResponse(
+    string AccessToken,
+    string RefreshToken,
+    DateTime ExpiresAt);

--- a/src/OpenTicket.Application.Contracts/Identity/Roles.cs
+++ b/src/OpenTicket.Application.Contracts/Identity/Roles.cs
@@ -1,9 +1,9 @@
 namespace OpenTicket.Application.Contracts.Identity;
 
 /// <summary>
-/// Well-known role names used throughout the application.
+/// Standard role names used throughout the application.
 /// </summary>
-public static class WellKnownRoles
+public static class Roles
 {
     /// <summary>
     /// Administrator role with full system access.

--- a/src/OpenTicket.Application.Contracts/Identity/WellKnownRoles.cs
+++ b/src/OpenTicket.Application.Contracts/Identity/WellKnownRoles.cs
@@ -1,0 +1,17 @@
+namespace OpenTicket.Application.Contracts.Identity;
+
+/// <summary>
+/// Well-known role names used throughout the application.
+/// </summary>
+public static class WellKnownRoles
+{
+    /// <summary>
+    /// Administrator role with full system access.
+    /// </summary>
+    public const string Admin = "Admin";
+
+    /// <summary>
+    /// Regular user role.
+    /// </summary>
+    public const string User = "User";
+}

--- a/src/OpenTicket.Application.Contracts/Notes/Commands/CreateNoteCommand.cs
+++ b/src/OpenTicket.Application.Contracts/Notes/Commands/CreateNoteCommand.cs
@@ -1,7 +1,8 @@
+using ErrorOr;
 using OpenTicket.Ddd.Application.Cqrs;
 
 namespace OpenTicket.Application.Contracts.Notes.Commands;
 
-public record CreateNoteCommand(string Title, string Body) : ICommand<CreateNoteCommandResult>;
+public record CreateNoteCommand(string Title, string Body) : ICommand<ErrorOr<CreateNoteCommandResult>>;
 
 public record CreateNoteCommandResult(Guid Id);

--- a/src/OpenTicket.Application.Contracts/Notes/Commands/PatchNoteCommand.cs
+++ b/src/OpenTicket.Application.Contracts/Notes/Commands/PatchNoteCommand.cs
@@ -1,3 +1,4 @@
+using ErrorOr;
 using OpenTicket.Ddd.Application.Cqrs;
 
 namespace OpenTicket.Application.Contracts.Notes.Commands;
@@ -6,4 +7,4 @@ namespace OpenTicket.Application.Contracts.Notes.Commands;
 /// Command for partially updating a note.
 /// Null values indicate fields that should not be changed.
 /// </summary>
-public record PatchNoteCommand(Guid Id, string? Title, string? Body) : ICommand<bool>;
+public record PatchNoteCommand(Guid Id, string? Title, string? Body) : ICommand<ErrorOr<Updated>>;

--- a/src/OpenTicket.Application.Contracts/Notes/Commands/RemoveNoteCommand.cs
+++ b/src/OpenTicket.Application.Contracts/Notes/Commands/RemoveNoteCommand.cs
@@ -1,5 +1,6 @@
+using ErrorOr;
 using OpenTicket.Ddd.Application.Cqrs;
 
 namespace OpenTicket.Application.Contracts.Notes.Commands;
 
-public record RemoveNoteCommand(Guid Id) : ICommand<bool>;
+public record RemoveNoteCommand(Guid Id) : ICommand<ErrorOr<Deleted>>;

--- a/src/OpenTicket.Application.Contracts/Notes/Commands/UpdateNoteCommand.cs
+++ b/src/OpenTicket.Application.Contracts/Notes/Commands/UpdateNoteCommand.cs
@@ -1,5 +1,6 @@
+using ErrorOr;
 using OpenTicket.Ddd.Application.Cqrs;
 
 namespace OpenTicket.Application.Contracts.Notes.Commands;
 
-public record UpdateNoteCommand(Guid Id, string Title, string Body) : ICommand<bool>;
+public record UpdateNoteCommand(Guid Id, string Title, string Body) : ICommand<ErrorOr<Updated>>;

--- a/src/OpenTicket.Application.Contracts/Notes/Dtos/NoteDto.cs
+++ b/src/OpenTicket.Application.Contracts/Notes/Dtos/NoteDto.cs
@@ -1,3 +1,10 @@
 namespace OpenTicket.Application.Contracts.Notes.Dtos;
 
-public record NoteDto(Guid Id, string Title, string Body, DateTime CreatedAt, DateTime? UpdatedAt);
+public record NoteDto(
+    Guid Id,
+    string Title,
+    string Body,
+    DateTime CreatedAt,
+    DateTime? UpdatedAt,
+    Guid CreatorId,
+    IReadOnlyList<Guid> SharedWith);

--- a/src/OpenTicket.Application.Contracts/Notes/Queries/GetNoteQuery.cs
+++ b/src/OpenTicket.Application.Contracts/Notes/Queries/GetNoteQuery.cs
@@ -1,6 +1,7 @@
+using ErrorOr;
 using OpenTicket.Application.Contracts.Notes.Dtos;
 using OpenTicket.Ddd.Application.Cqrs;
 
 namespace OpenTicket.Application.Contracts.Notes.Queries;
 
-public record GetNoteQuery(Guid Id) : IQuery<NoteDto?>;
+public record GetNoteQuery(Guid Id) : IQuery<ErrorOr<NoteDto>>;

--- a/src/OpenTicket.Application.Contracts/RateLimiting/IRateLimitService.cs
+++ b/src/OpenTicket.Application.Contracts/RateLimiting/IRateLimitService.cs
@@ -1,0 +1,57 @@
+using ErrorOr;
+using OpenTicket.Domain.Shared.Identities;
+
+namespace OpenTicket.Application.Contracts.RateLimiting;
+
+/// <summary>
+/// Service for handling rate limiting checks.
+/// </summary>
+public interface IRateLimitService
+{
+    /// <summary>
+    /// Checks if the user has exceeded their rate limit for a specific action.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="action">The action being rate limited.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Success if within limits, or an error.</returns>
+    Task<ErrorOr<Success>> CheckRateLimitAsync(
+        UserId userId,
+        RateLimitedAction action,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Records that a rate-limited action was performed.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="action">The action performed.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task RecordActionAsync(
+        UserId userId,
+        RateLimitedAction action,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the remaining quota for a user and action.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="action">The action.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The remaining count, or -1 for unlimited.</returns>
+    Task<int> GetRemainingQuotaAsync(
+        UserId userId,
+        RateLimitedAction action,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Actions that are subject to rate limiting.
+/// </summary>
+public enum RateLimitedAction
+{
+    /// <summary>
+    /// Creating a note.
+    /// Non-subscribers: 3/day, Subscribers: unlimited
+    /// </summary>
+    CreateNote
+}

--- a/src/OpenTicket.Application/Authorization/AuthorizationService.cs
+++ b/src/OpenTicket.Application/Authorization/AuthorizationService.cs
@@ -1,0 +1,71 @@
+using ErrorOr;
+using OpenTicket.Application.Contracts.Authorization;
+using OpenTicket.Application.Contracts.Identity;
+using OpenTicket.Domain.Notes.Entities;
+
+namespace OpenTicket.Application.Authorization;
+
+/// <summary>
+/// Authorization service implementation.
+/// </summary>
+public sealed class AuthorizationService : IAuthorizationService
+{
+    private readonly ICurrentUserProvider _currentUserProvider;
+
+    public AuthorizationService(ICurrentUserProvider currentUserProvider)
+    {
+        _currentUserProvider = currentUserProvider;
+    }
+
+    public CurrentUser CurrentUser => _currentUserProvider.CurrentUser;
+
+    public bool IsAdmin => CurrentUser.IsAdmin;
+
+    public Task<ErrorOr<Success>> AuthorizeAsync<TResource>(
+        TResource resource,
+        ResourceAction action,
+        CancellationToken ct = default)
+    {
+        if (!CurrentUser.IsAuthenticated)
+        {
+            return Task.FromResult<ErrorOr<Success>>(Error.Unauthorized(
+                "Authorization.Unauthenticated",
+                "User is not authenticated."));
+        }
+
+        // Admins can do anything
+        if (IsAdmin)
+        {
+            return Task.FromResult<ErrorOr<Success>>(Result.Success);
+        }
+
+        // Resource-specific authorization
+        var result = resource switch
+        {
+            Note note => AuthorizeNote(note, action),
+            _ => Result.Success
+        };
+
+        return Task.FromResult(result);
+    }
+
+    private ErrorOr<Success> AuthorizeNote(Note note, ResourceAction action)
+    {
+        var userId = CurrentUser.Id;
+
+        return action switch
+        {
+            ResourceAction.Read when !note.CanRead(userId) =>
+                Error.Forbidden(
+                    "Note.AccessDenied",
+                    "You don't have permission to read this note."),
+
+            ResourceAction.Update or ResourceAction.Delete when !note.CanModify(userId) =>
+                Error.Forbidden(
+                    "Note.ModifyDenied",
+                    "Only the creator can modify this note."),
+
+            _ => Result.Success
+        };
+    }
+}

--- a/src/OpenTicket.Application/Authorization/RequestAuthorizationService.cs
+++ b/src/OpenTicket.Application/Authorization/RequestAuthorizationService.cs
@@ -1,0 +1,76 @@
+using ErrorOr;
+using OpenTicket.Application.Contracts.Identity;
+using OpenTicket.Ddd.Application.Cqrs.Authorization;
+
+namespace OpenTicket.Application.Authorization;
+
+/// <summary>
+/// Implementation of request authorization service.
+/// Handles role-based and permission-based authorization for CQRS requests.
+/// </summary>
+public sealed class RequestAuthorizationService : IRequestAuthorizationService
+{
+    private readonly ICurrentUserProvider _currentUserProvider;
+
+    public RequestAuthorizationService(ICurrentUserProvider currentUserProvider)
+    {
+        _currentUserProvider = currentUserProvider;
+    }
+
+    public ErrorOr<Success> AuthorizeCurrentUser<TRequest>(
+        TRequest request,
+        IReadOnlyList<string> requiredRoles,
+        IReadOnlyList<string> requiredPermissions,
+        IReadOnlyList<string> requiredPolicies)
+    {
+        var currentUser = _currentUserProvider.CurrentUser;
+
+        // Check if user is authenticated
+        if (!currentUser.IsAuthenticated)
+        {
+            return Error.Unauthorized(
+                "Authorization.Unauthenticated",
+                "User is not authenticated.");
+        }
+
+        // Admin bypasses all authorization checks
+        if (currentUser.IsAdmin)
+        {
+            return Result.Success;
+        }
+
+        // Check required roles (user must have at least one)
+        if (requiredRoles.Count > 0)
+        {
+            var hasRequiredRole = requiredRoles.Any(role =>
+                currentUser.Roles.Contains(role, StringComparer.OrdinalIgnoreCase));
+
+            if (!hasRequiredRole)
+            {
+                return Error.Forbidden(
+                    "Authorization.MissingRole",
+                    $"User is missing required roles. Required one of: {string.Join(", ", requiredRoles)}");
+            }
+        }
+
+        // Check required permissions (user must have all)
+        // Note: Currently, permissions are not implemented in CurrentUser.
+        // This is a placeholder for future permission-based authorization.
+        if (requiredPermissions.Count > 0)
+        {
+            // TODO: Implement when permissions are added to CurrentUser
+            // For now, we skip permission checks
+        }
+
+        // Check required policies (all must pass)
+        // Note: Policy evaluation is not yet implemented.
+        // This is a placeholder for future policy-based authorization.
+        if (requiredPolicies.Count > 0)
+        {
+            // TODO: Implement when policy enforcement is added
+            // For now, we skip policy checks
+        }
+
+        return Result.Success;
+    }
+}

--- a/src/OpenTicket.Application/Notes/Commands/CreateNoteCommandHandler.cs
+++ b/src/OpenTicket.Application/Notes/Commands/CreateNoteCommandHandler.cs
@@ -1,6 +1,8 @@
+using ErrorOr;
 using OpenTicket.Application.Contracts.Identity;
 using OpenTicket.Application.Contracts.Notes.Commands;
 using OpenTicket.Application.Contracts.Notes.Events;
+using OpenTicket.Application.Contracts.RateLimiting;
 using OpenTicket.Ddd.Application.Cqrs;
 using OpenTicket.Ddd.Application.IntegrationEvents;
 using OpenTicket.Ddd.Infrastructure;
@@ -8,27 +10,47 @@ using OpenTicket.Domain.Notes.Entities;
 
 namespace OpenTicket.Application.Notes.Commands;
 
-public sealed class CreateNoteCommandHandler : ICommandHandler<CreateNoteCommand, CreateNoteCommandResult>
+public sealed class CreateNoteCommandHandler : ICommandHandler<CreateNoteCommand, ErrorOr<CreateNoteCommandResult>>
 {
     private readonly IRepository<Note> _noteRepository;
     private readonly ICurrentUserProvider _currentUserProvider;
     private readonly IIntegrationEventPublisher _eventPublisher;
+    private readonly IRateLimitService _rateLimitService;
 
     public CreateNoteCommandHandler(
         IRepository<Note> noteRepository,
         ICurrentUserProvider currentUserProvider,
-        IIntegrationEventPublisher eventPublisher)
+        IIntegrationEventPublisher eventPublisher,
+        IRateLimitService rateLimitService)
     {
         _noteRepository = noteRepository;
         _currentUserProvider = currentUserProvider;
         _eventPublisher = eventPublisher;
+        _rateLimitService = rateLimitService;
     }
 
-    public async Task<CreateNoteCommandResult> HandleAsync(CreateNoteCommand command, CancellationToken ct = default)
+    public async Task<ErrorOr<CreateNoteCommandResult>> HandleAsync(CreateNoteCommand command, CancellationToken ct = default)
     {
-        var note = Note.Create(command.Title, command.Body);
+        var currentUser = _currentUserProvider.CurrentUser;
+
+        // Check rate limit for non-subscribers (3 notes per day)
+        var rateLimitResult = await _rateLimitService.CheckRateLimitAsync(
+            currentUser.Id,
+            RateLimitedAction.CreateNote,
+            ct);
+
+        if (rateLimitResult.IsError)
+        {
+            return rateLimitResult.Errors;
+        }
+
+        // Create note with creator info
+        var note = Note.Create(command.Title, command.Body, currentUser.Id);
 
         await _noteRepository.InsertAsync(note, ct);
+
+        // Record the action for rate limiting
+        await _rateLimitService.RecordActionAsync(currentUser.Id, RateLimitedAction.CreateNote, ct);
 
         // Publish integration event for notification
         var @event = new NoteCreatedEvent

--- a/src/OpenTicket.Application/Notes/Commands/PatchNoteCommandHandler.cs
+++ b/src/OpenTicket.Application/Notes/Commands/PatchNoteCommandHandler.cs
@@ -1,3 +1,5 @@
+using ErrorOr;
+using OpenTicket.Application.Contracts.Authorization;
 using OpenTicket.Application.Contracts.Identity;
 using OpenTicket.Application.Contracts.Notes.Commands;
 using OpenTicket.Application.Contracts.Notes.Events;
@@ -8,28 +10,40 @@ using OpenTicket.Domain.Notes.Entities;
 
 namespace OpenTicket.Application.Notes.Commands;
 
-public sealed class PatchNoteCommandHandler : ICommandHandler<PatchNoteCommand, bool>
+public sealed class PatchNoteCommandHandler : ICommandHandler<PatchNoteCommand, ErrorOr<Updated>>
 {
     private readonly IRepository<Note> _noteRepository;
     private readonly ICurrentUserProvider _currentUserProvider;
     private readonly IIntegrationEventPublisher _eventPublisher;
+    private readonly IAuthorizationService _authorizationService;
 
     public PatchNoteCommandHandler(
         IRepository<Note> noteRepository,
         ICurrentUserProvider currentUserProvider,
-        IIntegrationEventPublisher eventPublisher)
+        IIntegrationEventPublisher eventPublisher,
+        IAuthorizationService authorizationService)
     {
         _noteRepository = noteRepository;
         _currentUserProvider = currentUserProvider;
         _eventPublisher = eventPublisher;
+        _authorizationService = authorizationService;
     }
 
-    public async Task<bool> HandleAsync(PatchNoteCommand command, CancellationToken ct = default)
+    public async Task<ErrorOr<Updated>> HandleAsync(PatchNoteCommand command, CancellationToken ct = default)
     {
         var note = await _noteRepository.FindAsync(command.Id, ct);
 
         if (note is null)
-            return false;
+        {
+            return Error.NotFound("Note.NotFound", "Note not found.");
+        }
+
+        // Check authorization - only creator or admin can update
+        var authResult = await _authorizationService.AuthorizeAsync(note, ResourceAction.Update, ct);
+        if (authResult.IsError)
+        {
+            return authResult.Errors;
+        }
 
         // Track patched fields
         var patchedFields = new List<string>();
@@ -57,6 +71,6 @@ public sealed class PatchNoteCommandHandler : ICommandHandler<PatchNoteCommand, 
 
         await _eventPublisher.PublishAsync(@event, ct);
 
-        return true;
+        return Result.Updated;
     }
 }

--- a/src/OpenTicket.Application/Notes/Commands/RemoveNoteCommandHandler.cs
+++ b/src/OpenTicket.Application/Notes/Commands/RemoveNoteCommandHandler.cs
@@ -1,3 +1,5 @@
+using ErrorOr;
+using OpenTicket.Application.Contracts.Authorization;
 using OpenTicket.Application.Contracts.Notes.Commands;
 using OpenTicket.Ddd.Application.Cqrs;
 using OpenTicket.Ddd.Infrastructure;
@@ -5,24 +7,37 @@ using OpenTicket.Domain.Notes.Entities;
 
 namespace OpenTicket.Application.Notes.Commands;
 
-public sealed class RemoveNoteCommandHandler : ICommandHandler<RemoveNoteCommand, bool>
+public sealed class RemoveNoteCommandHandler : ICommandHandler<RemoveNoteCommand, ErrorOr<Deleted>>
 {
     private readonly IRepository<Note> _noteRepository;
+    private readonly IAuthorizationService _authorizationService;
 
-    public RemoveNoteCommandHandler(IRepository<Note> noteRepository)
+    public RemoveNoteCommandHandler(
+        IRepository<Note> noteRepository,
+        IAuthorizationService authorizationService)
     {
         _noteRepository = noteRepository;
+        _authorizationService = authorizationService;
     }
 
-    public async Task<bool> HandleAsync(RemoveNoteCommand command, CancellationToken ct = default)
+    public async Task<ErrorOr<Deleted>> HandleAsync(RemoveNoteCommand command, CancellationToken ct = default)
     {
         var note = await _noteRepository.FindAsync(command.Id, ct);
 
         if (note is null)
-            return false;
+        {
+            return Error.NotFound("Note.NotFound", "Note not found.");
+        }
+
+        // Check authorization - only creator or admin can delete
+        var authResult = await _authorizationService.AuthorizeAsync(note, ResourceAction.Delete, ct);
+        if (authResult.IsError)
+        {
+            return authResult.Errors;
+        }
 
         await _noteRepository.DeleteAsync(note, ct);
 
-        return true;
+        return Result.Deleted;
     }
 }

--- a/src/OpenTicket.Application/Notes/Commands/UpdateNoteCommandHandler.cs
+++ b/src/OpenTicket.Application/Notes/Commands/UpdateNoteCommandHandler.cs
@@ -1,3 +1,5 @@
+using ErrorOr;
+using OpenTicket.Application.Contracts.Authorization;
 using OpenTicket.Application.Contracts.Identity;
 using OpenTicket.Application.Contracts.Notes.Commands;
 using OpenTicket.Application.Contracts.Notes.Events;
@@ -8,28 +10,40 @@ using OpenTicket.Domain.Notes.Entities;
 
 namespace OpenTicket.Application.Notes.Commands;
 
-public sealed class UpdateNoteCommandHandler : ICommandHandler<UpdateNoteCommand, bool>
+public sealed class UpdateNoteCommandHandler : ICommandHandler<UpdateNoteCommand, ErrorOr<Updated>>
 {
     private readonly IRepository<Note> _noteRepository;
     private readonly ICurrentUserProvider _currentUserProvider;
     private readonly IIntegrationEventPublisher _eventPublisher;
+    private readonly IAuthorizationService _authorizationService;
 
     public UpdateNoteCommandHandler(
         IRepository<Note> noteRepository,
         ICurrentUserProvider currentUserProvider,
-        IIntegrationEventPublisher eventPublisher)
+        IIntegrationEventPublisher eventPublisher,
+        IAuthorizationService authorizationService)
     {
         _noteRepository = noteRepository;
         _currentUserProvider = currentUserProvider;
         _eventPublisher = eventPublisher;
+        _authorizationService = authorizationService;
     }
 
-    public async Task<bool> HandleAsync(UpdateNoteCommand command, CancellationToken ct = default)
+    public async Task<ErrorOr<Updated>> HandleAsync(UpdateNoteCommand command, CancellationToken ct = default)
     {
         var note = await _noteRepository.FindAsync(command.Id, ct);
 
         if (note is null)
-            return false;
+        {
+            return Error.NotFound("Note.NotFound", "Note not found.");
+        }
+
+        // Check authorization - only creator or admin can update
+        var authResult = await _authorizationService.AuthorizeAsync(note, ResourceAction.Update, ct);
+        if (authResult.IsError)
+        {
+            return authResult.Errors;
+        }
 
         var previousTitle = note.Title;
         var previousBody = note.Body;
@@ -52,6 +66,6 @@ public sealed class UpdateNoteCommandHandler : ICommandHandler<UpdateNoteCommand
 
         await _eventPublisher.PublishAsync(@event, ct);
 
-        return true;
+        return Result.Updated;
     }
 }

--- a/src/OpenTicket.Application/Notes/Queries/GetNoteQueryHandler.cs
+++ b/src/OpenTicket.Application/Notes/Queries/GetNoteQueryHandler.cs
@@ -1,3 +1,5 @@
+using ErrorOr;
+using OpenTicket.Application.Contracts.Authorization;
 using OpenTicket.Application.Contracts.Notes.Dtos;
 using OpenTicket.Application.Contracts.Notes.Queries;
 using OpenTicket.Ddd.Application.Cqrs;
@@ -6,22 +8,42 @@ using OpenTicket.Domain.Notes.Entities;
 
 namespace OpenTicket.Application.Notes.Queries;
 
-public sealed class GetNoteQueryHandler : IQueryHandler<GetNoteQuery, NoteDto?>
+public sealed class GetNoteQueryHandler : IQueryHandler<GetNoteQuery, ErrorOr<NoteDto>>
 {
     private readonly IRepository<Note> _noteRepository;
+    private readonly IAuthorizationService _authorizationService;
 
-    public GetNoteQueryHandler(IRepository<Note> noteRepository)
+    public GetNoteQueryHandler(
+        IRepository<Note> noteRepository,
+        IAuthorizationService authorizationService)
     {
         _noteRepository = noteRepository;
+        _authorizationService = authorizationService;
     }
 
-    public async Task<NoteDto?> HandleAsync(GetNoteQuery query, CancellationToken ct = default)
+    public async Task<ErrorOr<NoteDto>> HandleAsync(GetNoteQuery query, CancellationToken ct = default)
     {
         var note = await _noteRepository.FindAsync(query.Id, ct);
 
         if (note is null)
-            return null;
+        {
+            return Error.NotFound("Note.NotFound", "Note not found.");
+        }
 
-        return new NoteDto(note.Id, note.Title, note.Body, note.CreatedAt, note.UpdatedAt);
+        // Check authorization - only creator, shared users, or admin can read
+        var authResult = await _authorizationService.AuthorizeAsync(note, ResourceAction.Read, ct);
+        if (authResult.IsError)
+        {
+            return authResult.Errors;
+        }
+
+        return new NoteDto(
+            note.Id,
+            note.Title,
+            note.Body,
+            note.CreatedAt,
+            note.UpdatedAt,
+            note.CreatorId.Value,
+            note.SharedWith.Select(u => u.Value).ToList());
     }
 }

--- a/src/OpenTicket.Application/Notes/Queries/GetNotesQueryHandler.cs
+++ b/src/OpenTicket.Application/Notes/Queries/GetNotesQueryHandler.cs
@@ -1,3 +1,4 @@
+using OpenTicket.Application.Contracts.Identity;
 using OpenTicket.Application.Contracts.Notes.Dtos;
 using OpenTicket.Application.Contracts.Notes.Queries;
 using OpenTicket.Ddd.Application.Cqrs;
@@ -9,18 +10,36 @@ namespace OpenTicket.Application.Notes.Queries;
 public sealed class GetNotesQueryHandler : IQueryHandler<GetNotesQuery, GetNotesQueryResult>
 {
     private readonly IRepository<Note> _noteRepository;
+    private readonly ICurrentUserProvider _currentUserProvider;
 
-    public GetNotesQueryHandler(IRepository<Note> noteRepository)
+    public GetNotesQueryHandler(
+        IRepository<Note> noteRepository,
+        ICurrentUserProvider currentUserProvider)
     {
         _noteRepository = noteRepository;
+        _currentUserProvider = currentUserProvider;
     }
 
     public async Task<GetNotesQueryResult> HandleAsync(GetNotesQuery query, CancellationToken ct = default)
     {
+        var currentUser = _currentUserProvider.CurrentUser;
         var notes = await _noteRepository.ListAllAsync(ct);
 
-        var dtos = notes
-            .Select(n => new NoteDto(n.Id, n.Title, n.Body, n.CreatedAt, n.UpdatedAt))
+        // Filter notes: user can see their own notes or notes shared with them
+        // Admins can see all notes
+        var visibleNotes = currentUser.IsAdmin
+            ? notes
+            : notes.Where(n => n.CanRead(currentUser.Id));
+
+        var dtos = visibleNotes
+            .Select(n => new NoteDto(
+                n.Id,
+                n.Title,
+                n.Body,
+                n.CreatedAt,
+                n.UpdatedAt,
+                n.CreatorId.Value,
+                n.SharedWith.Select(u => u.Value).ToList()))
             .ToList();
 
         return new GetNotesQueryResult(dtos);

--- a/src/OpenTicket.Application/OpenTicket.Application.csproj
+++ b/src/OpenTicket.Application/OpenTicket.Application.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\OpenTicket.Ddd\OpenTicket.Ddd.csproj" />
     <ProjectReference Include="..\OpenTicket.Domain\OpenTicket.Domain.csproj" />
     <ProjectReference Include="..\OpenTicket.Application.Contracts\OpenTicket.Application.Contracts.csproj" />
+    <ProjectReference Include="..\OpenTicket.Infrastructure.Cache\OpenTicket.Infrastructure.Cache.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/OpenTicket.Application/OpenTicketApplicationModule.cs
+++ b/src/OpenTicket.Application/OpenTicketApplicationModule.cs
@@ -1,6 +1,10 @@
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using OpenTicket.Application.Authorization;
+using OpenTicket.Application.Contracts.Authorization;
+using OpenTicket.Application.Contracts.RateLimiting;
+using OpenTicket.Application.RateLimiting;
 using OpenTicket.Application.Tickets.Settings;
 using OpenTicket.Ddd.Application.Cqrs;
 
@@ -25,6 +29,10 @@ public static class OpenTicketApplicationModule
 
         // Register integration events infrastructure
         services.AddIntegrationEvents();
+
+        // Register authorization and rate limiting services
+        services.AddScoped<IAuthorizationService, AuthorizationService>();
+        services.AddScoped<IRateLimitService, RateLimitService>();
 
         return services;
     }

--- a/src/OpenTicket.Application/OpenTicketApplicationModule.cs
+++ b/src/OpenTicket.Application/OpenTicketApplicationModule.cs
@@ -7,6 +7,7 @@ using OpenTicket.Application.Contracts.RateLimiting;
 using OpenTicket.Application.RateLimiting;
 using OpenTicket.Application.Tickets.Settings;
 using OpenTicket.Ddd.Application.Cqrs;
+using OpenTicket.Ddd.Application.Cqrs.Authorization;
 
 namespace OpenTicket.Application;
 
@@ -32,6 +33,7 @@ public static class OpenTicketApplicationModule
 
         // Register authorization and rate limiting services
         services.AddScoped<IAuthorizationService, AuthorizationService>();
+        services.AddScoped<IRequestAuthorizationService, RequestAuthorizationService>();
         services.AddScoped<IRateLimitService, RateLimitService>();
 
         return services;

--- a/src/OpenTicket.Application/RateLimiting/RateLimitService.cs
+++ b/src/OpenTicket.Application/RateLimiting/RateLimitService.cs
@@ -1,0 +1,123 @@
+using ErrorOr;
+using OpenTicket.Application.Contracts.Identity;
+using OpenTicket.Application.Contracts.RateLimiting;
+using OpenTicket.Domain.Shared.Identities;
+using OpenTicket.Infrastructure.Cache.Abstractions;
+
+namespace OpenTicket.Application.RateLimiting;
+
+/// <summary>
+/// Rate limiting service implementation using distributed cache.
+/// </summary>
+public sealed class RateLimitService : IRateLimitService
+{
+    private readonly IDistributedCache _cache;
+    private readonly ICurrentUserProvider _currentUserProvider;
+
+    private const int NonSubscriberDailyNoteLimit = 3;
+
+    public RateLimitService(
+        IDistributedCache cache,
+        ICurrentUserProvider currentUserProvider)
+    {
+        _cache = cache;
+        _currentUserProvider = currentUserProvider;
+    }
+
+    public async Task<ErrorOr<Success>> CheckRateLimitAsync(
+        UserId userId,
+        RateLimitedAction action,
+        CancellationToken ct = default)
+    {
+        var currentUser = _currentUserProvider.CurrentUser;
+
+        // Admins and subscribers have no rate limits
+        if (currentUser.IsAdmin || currentUser.HasSubscription)
+        {
+            return Result.Success;
+        }
+
+        var limit = GetLimit(action);
+        if (limit < 0) // -1 means unlimited
+        {
+            return Result.Success;
+        }
+
+        var key = GetRateLimitKey(userId, action);
+        var count = await _cache.GetAsync<int?>(key, ct) ?? 0;
+
+        if (count >= limit)
+        {
+            return Error.Forbidden(
+                "RateLimit.Exceeded",
+                $"Rate limit exceeded for {action}. Daily limit: {limit}. Upgrade to a subscription for unlimited access.");
+        }
+
+        return Result.Success;
+    }
+
+    public async Task RecordActionAsync(
+        UserId userId,
+        RateLimitedAction action,
+        CancellationToken ct = default)
+    {
+        var currentUser = _currentUserProvider.CurrentUser;
+
+        // Don't record for admins and subscribers
+        if (currentUser.IsAdmin || currentUser.HasSubscription)
+        {
+            return;
+        }
+
+        var key = GetRateLimitKey(userId, action);
+        var count = await _cache.GetAsync<int?>(key, ct) ?? 0;
+
+        // Set with TTL until end of day (UTC)
+        var ttl = GetTimeUntilMidnightUtc();
+        await _cache.SetAsync(key, count + 1, ttl, ct);
+    }
+
+    public async Task<int> GetRemainingQuotaAsync(
+        UserId userId,
+        RateLimitedAction action,
+        CancellationToken ct = default)
+    {
+        var currentUser = _currentUserProvider.CurrentUser;
+
+        // Admins and subscribers have unlimited quota
+        if (currentUser.IsAdmin || currentUser.HasSubscription)
+        {
+            return -1; // Unlimited
+        }
+
+        var limit = GetLimit(action);
+        if (limit < 0)
+        {
+            return -1;
+        }
+
+        var key = GetRateLimitKey(userId, action);
+        var count = await _cache.GetAsync<int?>(key, ct) ?? 0;
+
+        return Math.Max(0, limit - count);
+    }
+
+    private static int GetLimit(RateLimitedAction action) => action switch
+    {
+        RateLimitedAction.CreateNote => NonSubscriberDailyNoteLimit,
+        _ => -1
+    };
+
+    private static string GetRateLimitKey(UserId userId, RateLimitedAction action)
+    {
+        var today = DateTime.UtcNow.ToString("yyyy-MM-dd");
+        return $"ratelimit:{action}:{userId.Value}:{today}";
+    }
+
+    private static TimeSpan GetTimeUntilMidnightUtc()
+    {
+        var now = DateTime.UtcNow;
+        var midnight = now.Date.AddDays(1);
+        return midnight - now;
+    }
+}

--- a/src/OpenTicket.Ddd/Application/Cqrs/Authorization/AuthorizeAttribute.cs
+++ b/src/OpenTicket.Ddd/Application/Cqrs/Authorization/AuthorizeAttribute.cs
@@ -1,0 +1,40 @@
+namespace OpenTicket.Ddd.Application.Cqrs.Authorization;
+
+/// <summary>
+/// Marks a request as requiring authorization.
+/// Can be applied multiple times to require multiple authorization conditions.
+/// </summary>
+/// <example>
+/// <code>
+/// [Authorize(Roles = "Admin,User")]
+/// [Authorize(Permissions = "Note.Create")]
+/// public class CreateNoteCommand : ICommand&lt;ErrorOr&lt;NoteId&gt;&gt;, IAuthorizeableRequest&lt;ErrorOr&lt;NoteId&gt;&gt;
+/// {
+///     public Guid? UserId { get; init; }
+/// }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public sealed class AuthorizeAttribute : Attribute
+{
+    /// <summary>
+    /// Comma-separated list of required permissions.
+    /// User must have ALL specified permissions.
+    /// </summary>
+    /// <example>"Note.Create,Note.Update"</example>
+    public string? Permissions { get; set; }
+
+    /// <summary>
+    /// Comma-separated list of required roles.
+    /// User must have at least ONE of the specified roles.
+    /// </summary>
+    /// <example>"Admin,User"</example>
+    public string? Roles { get; set; }
+
+    /// <summary>
+    /// Comma-separated list of policy names to evaluate.
+    /// All policies must pass.
+    /// </summary>
+    /// <example>"ResourceOwner,ActiveSubscription"</example>
+    public string? Policies { get; set; }
+}

--- a/src/OpenTicket.Ddd/Application/Cqrs/Authorization/IAuthorizeableRequest.cs
+++ b/src/OpenTicket.Ddd/Application/Cqrs/Authorization/IAuthorizeableRequest.cs
@@ -1,0 +1,38 @@
+namespace OpenTicket.Ddd.Application.Cqrs.Authorization;
+
+/// <summary>
+/// Marker interface for requests that require authorization.
+/// </summary>
+/// <typeparam name="TResponse">The response type.</typeparam>
+public interface IAuthorizeableRequest<TResponse>;
+
+/// <summary>
+/// Command that requires authorization checks.
+/// Use this instead of ICommand when you want to apply [Authorize] attributes.
+/// </summary>
+/// <typeparam name="TResult">The result type.</typeparam>
+/// <example>
+/// <code>
+/// [Authorize(Roles = "Admin,User")]
+/// public record CreateNoteCommand(string Title) : IAuthorizeableCommand&lt;ErrorOr&lt;NoteId&gt;&gt;;
+/// </code>
+/// </example>
+public interface IAuthorizeableCommand<TResult> : ICommand<TResult>, IAuthorizeableRequest<TResult>;
+
+/// <summary>
+/// Command without result that requires authorization checks.
+/// </summary>
+public interface IAuthorizeableCommand : IAuthorizeableCommand<Unit>;
+
+/// <summary>
+/// Query that requires authorization checks.
+/// Use this instead of IQuery when you want to apply [Authorize] attributes.
+/// </summary>
+/// <typeparam name="TResult">The result type.</typeparam>
+/// <example>
+/// <code>
+/// [Authorize(Roles = "User")]
+/// public record GetNoteQuery(Guid Id) : IAuthorizeableQuery&lt;ErrorOr&lt;NoteResponse&gt;&gt;;
+/// </code>
+/// </example>
+public interface IAuthorizeableQuery<TResult> : IQuery<TResult>, IAuthorizeableRequest<TResult>;

--- a/src/OpenTicket.Ddd/Application/Cqrs/Authorization/IRequestAuthorizationService.cs
+++ b/src/OpenTicket.Ddd/Application/Cqrs/Authorization/IRequestAuthorizationService.cs
@@ -1,0 +1,25 @@
+using ErrorOr;
+
+namespace OpenTicket.Ddd.Application.Cqrs.Authorization;
+
+/// <summary>
+/// Service for authorizing requests based on roles, permissions, and policies.
+/// Used by <see cref="Behaviors.AuthorizationBehavior{TRequest,TResponse}"/> for AOP-style authorization.
+/// </summary>
+public interface IRequestAuthorizationService
+{
+    /// <summary>
+    /// Authorizes the current user for a request based on required roles, permissions, and policies.
+    /// </summary>
+    /// <typeparam name="TRequest">The request type.</typeparam>
+    /// <param name="request">The request being authorized.</param>
+    /// <param name="requiredRoles">Roles the user must have (at least one).</param>
+    /// <param name="requiredPermissions">Permissions the user must have (all).</param>
+    /// <param name="requiredPolicies">Policies that must pass (all).</param>
+    /// <returns>Success if authorized, or an error.</returns>
+    ErrorOr<Success> AuthorizeCurrentUser<TRequest>(
+        TRequest request,
+        IReadOnlyList<string> requiredRoles,
+        IReadOnlyList<string> requiredPermissions,
+        IReadOnlyList<string> requiredPolicies);
+}

--- a/src/OpenTicket.Ddd/Application/Cqrs/Behaviors/AuthorizationBehavior.cs
+++ b/src/OpenTicket.Ddd/Application/Cqrs/Behaviors/AuthorizationBehavior.cs
@@ -1,0 +1,69 @@
+using System.Reflection;
+using ErrorOr;
+using OpenTicket.Ddd.Application.Cqrs.Authorization;
+
+namespace OpenTicket.Ddd.Application.Cqrs.Behaviors;
+
+/// <summary>
+/// Pipeline behavior that enforces authorization based on <see cref="AuthorizeAttribute"/> decorations.
+/// Only applies to requests that implement <see cref="IAuthorizeableRequest{TResponse}"/>.
+/// </summary>
+/// <typeparam name="TRequest">The type of request.</typeparam>
+/// <typeparam name="TResponse">The type of response (must implement IErrorOr).</typeparam>
+public sealed class AuthorizationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IAuthorizeableRequest<TResponse>
+    where TResponse : IErrorOr
+{
+    private readonly IRequestAuthorizationService _authorizationService;
+
+    public AuthorizationBehavior(IRequestAuthorizationService authorizationService)
+    {
+        _authorizationService = authorizationService;
+    }
+
+    public async Task<TResponse> HandleAsync(
+        TRequest request,
+        Func<Task<TResponse>> next,
+        CancellationToken ct = default)
+    {
+        var authorizationAttributes = request.GetType()
+            .GetCustomAttributes<AuthorizeAttribute>()
+            .ToList();
+
+        if (authorizationAttributes.Count == 0)
+        {
+            return await next();
+        }
+
+        var requiredPermissions = authorizationAttributes
+            .SelectMany(attr => attr.Permissions?.Split(',', StringSplitOptions.RemoveEmptyEntries) ?? [])
+            .Select(p => p.Trim())
+            .Distinct()
+            .ToList();
+
+        var requiredRoles = authorizationAttributes
+            .SelectMany(attr => attr.Roles?.Split(',', StringSplitOptions.RemoveEmptyEntries) ?? [])
+            .Select(r => r.Trim())
+            .Distinct()
+            .ToList();
+
+        var requiredPolicies = authorizationAttributes
+            .SelectMany(attr => attr.Policies?.Split(',', StringSplitOptions.RemoveEmptyEntries) ?? [])
+            .Select(p => p.Trim())
+            .Distinct()
+            .ToList();
+
+        var authorizationResult = _authorizationService.AuthorizeCurrentUser(
+            request,
+            requiredRoles,
+            requiredPermissions,
+            requiredPolicies);
+
+        if (authorizationResult.IsError)
+        {
+            return (dynamic)authorizationResult.Errors;
+        }
+
+        return await next();
+    }
+}

--- a/src/OpenTicket.Domain/Notes/Entities/Note.cs
+++ b/src/OpenTicket.Domain/Notes/Entities/Note.cs
@@ -1,4 +1,5 @@
 using OpenTicket.Ddd.Domain;
+using OpenTicket.Domain.Shared.Identities;
 
 namespace OpenTicket.Domain.Notes.Entities;
 
@@ -7,20 +8,33 @@ namespace OpenTicket.Domain.Notes.Entities;
 /// </summary>
 public class Note : AggregateRoot
 {
+    private readonly List<UserId> _sharedWith = [];
+
     public string Title { get; private set; } = string.Empty;
     public string Body { get; private set; } = string.Empty;
     public DateTime CreatedAt { get; private set; }
     public DateTime? UpdatedAt { get; private set; }
 
+    /// <summary>
+    /// The user who created this note.
+    /// </summary>
+    public UserId CreatorId { get; private set; }
+
+    /// <summary>
+    /// List of user IDs this note is shared with.
+    /// </summary>
+    public IReadOnlyList<UserId> SharedWith => _sharedWith.AsReadOnly();
+
     private Note() { } // EF Core
 
-    public static Note Create(string title, string body)
+    public static Note Create(string title, string body, UserId creatorId)
     {
         return new Note
         {
             Id = Guid.NewGuid(),
             Title = title,
             Body = body,
+            CreatorId = creatorId,
             CreatedAt = DateTime.UtcNow
         };
     }
@@ -31,4 +45,44 @@ public class Note : AggregateRoot
         Body = body;
         UpdatedAt = DateTime.UtcNow;
     }
+
+    /// <summary>
+    /// Shares this note with a user.
+    /// </summary>
+    public void ShareWith(UserId userId)
+    {
+        if (!_sharedWith.Contains(userId) && userId != CreatorId)
+        {
+            _sharedWith.Add(userId);
+            UpdatedAt = DateTime.UtcNow;
+        }
+    }
+
+    /// <summary>
+    /// Removes sharing with a user.
+    /// </summary>
+    public void UnshareWith(UserId userId)
+    {
+        if (_sharedWith.Remove(userId))
+        {
+            UpdatedAt = DateTime.UtcNow;
+        }
+    }
+
+    /// <summary>
+    /// Checks if the note is shared with a user.
+    /// </summary>
+    public bool IsSharedWith(UserId userId) => _sharedWith.Contains(userId);
+
+    /// <summary>
+    /// Checks if a user can read this note.
+    /// A user can read a note if they are the creator or the note is shared with them.
+    /// </summary>
+    public bool CanRead(UserId userId) => CreatorId == userId || IsSharedWith(userId);
+
+    /// <summary>
+    /// Checks if a user can modify (update/delete) this note.
+    /// Only the creator can modify a note.
+    /// </summary>
+    public bool CanModify(UserId userId) => CreatorId == userId;
 }

--- a/src/OpenTicket.Infrastructure.Identity/Mock/MockAuthenticationHandler.cs
+++ b/src/OpenTicket.Infrastructure.Identity/Mock/MockAuthenticationHandler.cs
@@ -1,0 +1,52 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace OpenTicket.Infrastructure.Identity.Mock;
+
+/// <summary>
+/// Mock authentication handler that always succeeds with claims from MockUserOptions.
+/// Used for development and testing when no real authentication is configured.
+/// </summary>
+public class MockAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    private readonly MockUserOptions _mockUserOptions;
+
+    public MockAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        IOptions<MockUserOptions> mockUserOptions)
+        : base(options, logger, encoder)
+    {
+        _mockUserOptions = mockUserOptions.Value;
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, _mockUserOptions.UserId.ToString()),
+            new(ClaimTypes.Email, _mockUserOptions.Email),
+            new(ClaimTypes.Name, _mockUserOptions.Name),
+            new("provider", "Mock")
+        };
+
+        // Add role claims
+        foreach (var role in _mockUserOptions.Roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        // Add subscription claim
+        claims.Add(new Claim("has_subscription", _mockUserOptions.HasSubscription.ToString().ToLowerInvariant()));
+
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/src/OpenTicket.Infrastructure.Identity/Mock/MockCurrentUserProvider.cs
+++ b/src/OpenTicket.Infrastructure.Identity/Mock/MockCurrentUserProvider.cs
@@ -22,7 +22,8 @@ public sealed class MockCurrentUserProvider : ICurrentUserProvider
             Name = opt.Name,
             IsAuthenticated = true,
             Provider = "Mock",
-            Roles = opt.Roles
+            Roles = opt.Roles,
+            HasSubscription = opt.HasSubscription
         };
     }
 

--- a/src/OpenTicket.Infrastructure.Identity/Mock/MockUserOptions.cs
+++ b/src/OpenTicket.Infrastructure.Identity/Mock/MockUserOptions.cs
@@ -30,4 +30,9 @@ public class MockUserOptions
     /// The mock user's roles.
     /// </summary>
     public List<string> Roles { get; set; } = ["User"];
+
+    /// <summary>
+    /// Whether the mock user has an active subscription.
+    /// </summary>
+    public bool HasSubscription { get; set; } = false;
 }

--- a/src/OpenTicket.Infrastructure.Identity/OAuth/JwtCurrentUserProvider.cs
+++ b/src/OpenTicket.Infrastructure.Identity/OAuth/JwtCurrentUserProvider.cs
@@ -1,0 +1,72 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using OpenTicket.Application.Contracts.Identity;
+using OpenTicket.Domain.Shared.Identities;
+
+namespace OpenTicket.Infrastructure.Identity.OAuth;
+
+/// <summary>
+/// JWT-based current user provider that extracts user info from JWT claims.
+/// </summary>
+public sealed class JwtCurrentUserProvider : ICurrentUserProvider
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private CurrentUser? _cachedUser;
+
+    public JwtCurrentUserProvider(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public CurrentUser CurrentUser => _cachedUser ??= GetCurrentUser();
+
+    private CurrentUser GetCurrentUser()
+    {
+        var httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext?.User?.Identity?.IsAuthenticated != true)
+        {
+            return CurrentUser.Anonymous;
+        }
+
+        var claims = httpContext.User.Claims.ToList();
+
+        var userIdClaim = claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Sub)?.Value
+            ?? claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
+
+        if (!Guid.TryParse(userIdClaim, out var userId))
+        {
+            return CurrentUser.Anonymous;
+        }
+
+        var email = claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Email)?.Value
+            ?? claims.FirstOrDefault(c => c.Type == ClaimTypes.Email)?.Value
+            ?? string.Empty;
+
+        var name = claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Name)?.Value
+            ?? claims.FirstOrDefault(c => c.Type == ClaimTypes.Name)?.Value
+            ?? string.Empty;
+
+        var roles = claims
+            .Where(c => c.Type == ClaimTypes.Role)
+            .Select(c => c.Value)
+            .ToList();
+
+        var hasSubscription = claims
+            .FirstOrDefault(c => c.Type == "has_subscription")?.Value
+            .Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+
+        var provider = claims.FirstOrDefault(c => c.Type == "provider")?.Value;
+
+        return new CurrentUser
+        {
+            Id = UserId.From(userId),
+            Email = email,
+            Name = name,
+            IsAuthenticated = true,
+            Provider = provider,
+            Roles = roles,
+            HasSubscription = hasSubscription
+        };
+    }
+}

--- a/src/OpenTicket.Infrastructure.Identity/OAuth/JwtTokenService.cs
+++ b/src/OpenTicket.Infrastructure.Identity/OAuth/JwtTokenService.cs
@@ -1,0 +1,70 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using OpenTicket.Application.Contracts.Identity;
+
+namespace OpenTicket.Infrastructure.Identity.OAuth;
+
+/// <summary>
+/// JWT token generation service.
+/// </summary>
+public sealed class JwtTokenService : ITokenService
+{
+    private readonly OAuthOptions _options;
+
+    public JwtTokenService(IOptions<OAuthOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public string GenerateAccessToken(CurrentUser user)
+    {
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.Id.Value.ToString()),
+            new(JwtRegisteredClaimNames.Email, user.Email),
+            new(JwtRegisteredClaimNames.Name, user.Name),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new("has_subscription", user.HasSubscription.ToString().ToLower())
+        };
+
+        // Add roles as claims
+        foreach (var role in user.Roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        if (user.Provider != null)
+        {
+            claims.Add(new Claim("provider", user.Provider));
+        }
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_options.Jwt.SecretKey));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: _options.Jwt.Issuer,
+            audience: _options.Jwt.Audience,
+            claims: claims,
+            expires: GetAccessTokenExpiration(),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    public string GenerateRefreshToken()
+    {
+        var randomBytes = new byte[64];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(randomBytes);
+        return Convert.ToBase64String(randomBytes);
+    }
+
+    public DateTime GetAccessTokenExpiration()
+    {
+        return DateTime.UtcNow.AddMinutes(_options.Jwt.AccessTokenExpirationMinutes);
+    }
+}

--- a/src/OpenTicket.Infrastructure.Identity/OAuth/OAuthOptions.cs
+++ b/src/OpenTicket.Infrastructure.Identity/OAuth/OAuthOptions.cs
@@ -1,0 +1,86 @@
+namespace OpenTicket.Infrastructure.Identity.OAuth;
+
+/// <summary>
+/// Configuration options for OAuth authentication.
+/// </summary>
+public class OAuthOptions
+{
+    public const string SectionName = "OAuth";
+
+    /// <summary>
+    /// JWT settings for token generation and validation.
+    /// </summary>
+    public JwtSettings Jwt { get; set; } = new();
+
+    /// <summary>
+    /// Google OAuth configuration.
+    /// </summary>
+    public OAuthProviderSettings? Google { get; set; }
+
+    /// <summary>
+    /// Facebook OAuth configuration.
+    /// </summary>
+    public OAuthProviderSettings? Facebook { get; set; }
+
+    /// <summary>
+    /// GitHub OAuth configuration.
+    /// </summary>
+    public OAuthProviderSettings? GitHub { get; set; }
+
+    /// <summary>
+    /// Apple OAuth configuration.
+    /// </summary>
+    public OAuthProviderSettings? Apple { get; set; }
+}
+
+/// <summary>
+/// JWT token settings.
+/// </summary>
+public class JwtSettings
+{
+    /// <summary>
+    /// Secret key for signing tokens.
+    /// </summary>
+    public string SecretKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Token issuer.
+    /// </summary>
+    public string Issuer { get; set; } = "OpenTicket";
+
+    /// <summary>
+    /// Token audience.
+    /// </summary>
+    public string Audience { get; set; } = "OpenTicket";
+
+    /// <summary>
+    /// Access token expiration in minutes.
+    /// </summary>
+    public int AccessTokenExpirationMinutes { get; set; } = 60;
+
+    /// <summary>
+    /// Refresh token expiration in days.
+    /// </summary>
+    public int RefreshTokenExpirationDays { get; set; } = 7;
+}
+
+/// <summary>
+/// OAuth provider-specific settings.
+/// </summary>
+public class OAuthProviderSettings
+{
+    /// <summary>
+    /// Whether this provider is enabled.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// OAuth client ID.
+    /// </summary>
+    public string ClientId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// OAuth client secret.
+    /// </summary>
+    public string ClientSecret { get; set; } = string.Empty;
+}

--- a/src/OpenTicket.Infrastructure.Identity/OAuth/OAuthOptions.cs
+++ b/src/OpenTicket.Infrastructure.Identity/OAuth/OAuthOptions.cs
@@ -28,9 +28,14 @@ public class OAuthOptions
     public OAuthProviderSettings? GitHub { get; set; }
 
     /// <summary>
+    /// Microsoft OAuth configuration.
+    /// </summary>
+    public OAuthProviderSettings? Microsoft { get; set; }
+
+    /// <summary>
     /// Apple OAuth configuration.
     /// </summary>
-    public OAuthProviderSettings? Apple { get; set; }
+    public AppleOAuthSettings? Apple { get; set; }
 }
 
 /// <summary>
@@ -83,4 +88,25 @@ public class OAuthProviderSettings
     /// OAuth client secret.
     /// </summary>
     public string ClientSecret { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Apple-specific OAuth settings (Sign in with Apple requires additional configuration).
+/// </summary>
+public class AppleOAuthSettings : OAuthProviderSettings
+{
+    /// <summary>
+    /// Apple Developer Team ID.
+    /// </summary>
+    public string TeamId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Key ID for the private key.
+    /// </summary>
+    public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Path to the .p8 private key file, or the key content itself.
+    /// </summary>
+    public string PrivateKey { get; set; } = string.Empty;
 }

--- a/src/OpenTicket.Infrastructure.Identity/OAuth/OAuthProviders.cs
+++ b/src/OpenTicket.Infrastructure.Identity/OAuth/OAuthProviders.cs
@@ -1,0 +1,74 @@
+namespace OpenTicket.Infrastructure.Identity.OAuth;
+
+/// <summary>
+/// Flags enum for selecting OAuth providers to enable.
+/// </summary>
+[Flags]
+public enum OAuthProviders
+{
+    /// <summary>
+    /// No OAuth providers enabled.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Google OAuth provider.
+    /// </summary>
+    Google = 1 << 0,
+
+    /// <summary>
+    /// Facebook OAuth provider.
+    /// </summary>
+    Facebook = 1 << 1,
+
+    /// <summary>
+    /// GitHub OAuth provider.
+    /// </summary>
+    GitHub = 1 << 2,
+
+    /// <summary>
+    /// Microsoft OAuth provider.
+    /// </summary>
+    Microsoft = 1 << 3,
+
+    /// <summary>
+    /// Apple OAuth provider.
+    /// </summary>
+    Apple = 1 << 4,
+
+    /// <summary>
+    /// All OAuth providers.
+    /// </summary>
+    All = Google | Facebook | GitHub | Microsoft | Apple
+}
+
+/// <summary>
+/// Configuration for enabled OAuth providers.
+/// </summary>
+public sealed class EnabledOAuthProviders(OAuthProviders providers)
+{
+    /// <summary>
+    /// The enabled OAuth providers.
+    /// </summary>
+    public OAuthProviders Providers { get; } = providers;
+
+    public bool IsEnabled(OAuthProviders provider) => Providers.HasFlag(provider);
+
+    public IReadOnlyList<string> GetProviderNames()
+    {
+        var names = new List<string>();
+
+        if (Providers.HasFlag(OAuthProviders.Google))
+            names.Add("Google");
+        if (Providers.HasFlag(OAuthProviders.Facebook))
+            names.Add("Facebook");
+        if (Providers.HasFlag(OAuthProviders.GitHub))
+            names.Add("GitHub");
+        if (Providers.HasFlag(OAuthProviders.Microsoft))
+            names.Add("Microsoft");
+        if (Providers.HasFlag(OAuthProviders.Apple))
+            names.Add("Apple");
+
+        return names;
+    }
+}

--- a/src/OpenTicket.Infrastructure.Identity/OpenTicket.Infrastructure.Identity.csproj
+++ b/src/OpenTicket.Infrastructure.Identity/OpenTicket.Infrastructure.Identity.csproj
@@ -7,9 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTicket.Infrastructure.Identity/OpenTicket.Infrastructure.Identity.csproj
+++ b/src/OpenTicket.Infrastructure.Identity/OpenTicket.Infrastructure.Identity.csproj
@@ -7,7 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />

--- a/src/OpenTicket.Infrastructure.Identity/OpenTicketInfrastructureIdentityModule.cs
+++ b/src/OpenTicket.Infrastructure.Identity/OpenTicketInfrastructureIdentityModule.cs
@@ -42,6 +42,7 @@ public static class OpenTicketInfrastructureIdentityModule
 
     /// <summary>
     /// Adds mock identity provider for development and testing.
+    /// Configures a pass-through authentication handler that always succeeds.
     /// </summary>
     public static IServiceCollection AddMockIdentity(
         this IServiceCollection services,
@@ -50,6 +51,14 @@ public static class OpenTicketInfrastructureIdentityModule
         services.Configure<MockUserOptions>(
             configuration.GetSection(MockUserOptions.SectionName));
 
+        // Add authentication with mock handler that always succeeds
+        services.AddAuthentication("Mock")
+            .AddScheme<AuthenticationSchemeOptions, MockAuthenticationHandler>("Mock", null);
+
+        // Add authorization
+        services.AddAuthorization();
+
+        services.AddHttpContextAccessor();
         services.AddScoped<ICurrentUserProvider, MockCurrentUserProvider>();
 
         return services;

--- a/src/OpenTicket.Infrastructure.Identity/OpenTicketInfrastructureIdentityModule.cs
+++ b/src/OpenTicket.Infrastructure.Identity/OpenTicketInfrastructureIdentityModule.cs
@@ -1,15 +1,44 @@
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
 using OpenTicket.Application.Contracts.Identity;
 using OpenTicket.Infrastructure.Identity.Mock;
+using OpenTicket.Infrastructure.Identity.OAuth;
 
 namespace OpenTicket.Infrastructure.Identity;
+
+/// <summary>
+/// Identity provider options.
+/// </summary>
+public enum IdentityProvider
+{
+    Mock,
+    OAuth
+}
 
 /// <summary>
 /// Module for registering identity services.
 /// </summary>
 public static class OpenTicketInfrastructureIdentityModule
 {
+    /// <summary>
+    /// Adds identity services based on the specified provider.
+    /// </summary>
+    public static IServiceCollection AddIdentity(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IdentityProvider provider)
+    {
+        return provider switch
+        {
+            IdentityProvider.Mock => AddMockIdentity(services, configuration),
+            IdentityProvider.OAuth => AddOAuthIdentity(services, configuration),
+            _ => throw new ArgumentOutOfRangeException(nameof(provider))
+        };
+    }
+
     /// <summary>
     /// Adds mock identity provider for development and testing.
     /// </summary>
@@ -38,5 +67,46 @@ public static class OpenTicketInfrastructureIdentityModule
         return services;
     }
 
-    // Future: AddGoogleIdentity, AddGitHubIdentity, AddAppleIdentity
+    /// <summary>
+    /// Adds OAuth/JWT identity provider for production.
+    /// Supports Google, Facebook, GitHub, and Apple OAuth providers.
+    /// </summary>
+    public static IServiceCollection AddOAuthIdentity(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var oauthOptions = configuration.GetSection(OAuthOptions.SectionName).Get<OAuthOptions>()
+            ?? new OAuthOptions();
+
+        services.Configure<OAuthOptions>(configuration.GetSection(OAuthOptions.SectionName));
+
+        // Add JWT Bearer authentication
+        services.AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        })
+        .AddJwtBearer(options =>
+        {
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                ValidIssuer = oauthOptions.Jwt.Issuer,
+                ValidAudience = oauthOptions.Jwt.Audience,
+                IssuerSigningKey = new SymmetricSecurityKey(
+                    Encoding.UTF8.GetBytes(oauthOptions.Jwt.SecretKey)),
+                ClockSkew = TimeSpan.Zero
+            };
+        });
+
+        // Register services
+        services.AddHttpContextAccessor();
+        services.AddScoped<ICurrentUserProvider, JwtCurrentUserProvider>();
+        services.AddScoped<ITokenService, JwtTokenService>();
+
+        return services;
+    }
 }

--- a/src/OpenTicket.Infrastructure.Identity/OpenTicketInfrastructureIdentityModule.cs
+++ b/src/OpenTicket.Infrastructure.Identity/OpenTicketInfrastructureIdentityModule.cs
@@ -88,17 +88,18 @@ public static class OpenTicketInfrastructureIdentityModule
             ?? new OAuthOptions();
 
         // Determine which providers to enable based on configuration
+        // Only enable if Enabled=true AND credentials are configured
         var providers = OAuthProviders.None;
 
-        if (oauthOptions.Google?.Enabled == true)
+        if (IsProviderConfigured(oauthOptions.Google))
             providers |= OAuthProviders.Google;
-        if (oauthOptions.Facebook?.Enabled == true)
+        if (IsProviderConfigured(oauthOptions.Facebook))
             providers |= OAuthProviders.Facebook;
-        if (oauthOptions.GitHub?.Enabled == true)
+        if (IsProviderConfigured(oauthOptions.GitHub))
             providers |= OAuthProviders.GitHub;
-        if (oauthOptions.Microsoft?.Enabled == true)
+        if (IsProviderConfigured(oauthOptions.Microsoft))
             providers |= OAuthProviders.Microsoft;
-        if (oauthOptions.Apple?.Enabled == true)
+        if (IsProviderConfigured(oauthOptions.Apple))
             providers |= OAuthProviders.Apple;
 
         return AddOAuthIdentity(services, configuration, providers);
@@ -231,5 +232,15 @@ public static class OpenTicketInfrastructureIdentityModule
         services.AddSingleton(new EnabledOAuthProviders(providers));
 
         return services;
+    }
+
+    /// <summary>
+    /// Checks if an OAuth provider is properly configured (enabled and has credentials).
+    /// </summary>
+    private static bool IsProviderConfigured(OAuthProviderSettings? settings)
+    {
+        return settings is { Enabled: true }
+            && !string.IsNullOrWhiteSpace(settings.ClientId)
+            && !string.IsNullOrWhiteSpace(settings.ClientSecret);
     }
 }

--- a/tests/OpenTicket.Application.Tests/Authorization/AuthorizationServiceTests.cs
+++ b/tests/OpenTicket.Application.Tests/Authorization/AuthorizationServiceTests.cs
@@ -1,0 +1,209 @@
+using NSubstitute;
+using OpenTicket.Application.Authorization;
+using OpenTicket.Application.Contracts.Authorization;
+using OpenTicket.Application.Contracts.Identity;
+using OpenTicket.Domain.Notes.Entities;
+using OpenTicket.Domain.Shared.Identities;
+using Shouldly;
+
+namespace OpenTicket.Application.Tests.Authorization;
+
+public class AuthorizationServiceTests
+{
+    private readonly ICurrentUserProvider _currentUserProvider;
+    private readonly AuthorizationService _sut;
+
+    public AuthorizationServiceTests()
+    {
+        _currentUserProvider = Substitute.For<ICurrentUserProvider>();
+        _sut = new AuthorizationService(_currentUserProvider);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenUserNotAuthenticated_ReturnsUnauthorized()
+    {
+        // Arrange
+        var user = new CurrentUser
+        {
+            Id = UserId.New(),
+            Email = "",
+            Name = "",
+            Roles = [],
+            IsAuthenticated = false
+        };
+        _currentUserProvider.CurrentUser.Returns(user);
+        var note = Note.Create("Test", "Body", UserId.New());
+
+        // Act
+        var result = await _sut.AuthorizeAsync(note, ResourceAction.Read);
+
+        // Assert
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Code.ShouldBe("Authorization.Unauthenticated");
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenAdmin_AlwaysAllowsAccess()
+    {
+        // Arrange
+        var adminUser = CreateUser(isAdmin: true);
+        _currentUserProvider.CurrentUser.Returns(adminUser);
+
+        var otherUserId = UserId.New();
+        var note = Note.Create("Test", "Body", otherUserId);
+
+        // Act - even though admin is not the creator
+        var readResult = await _sut.AuthorizeAsync(note, ResourceAction.Read);
+        var updateResult = await _sut.AuthorizeAsync(note, ResourceAction.Update);
+        var deleteResult = await _sut.AuthorizeAsync(note, ResourceAction.Delete);
+
+        // Assert
+        readResult.IsError.ShouldBeFalse();
+        updateResult.IsError.ShouldBeFalse();
+        deleteResult.IsError.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenCreator_CanReadModifyDelete()
+    {
+        // Arrange
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+        _currentUserProvider.CurrentUser.Returns(user);
+
+        var note = Note.Create("Test", "Body", userId);
+
+        // Act
+        var readResult = await _sut.AuthorizeAsync(note, ResourceAction.Read);
+        var updateResult = await _sut.AuthorizeAsync(note, ResourceAction.Update);
+        var deleteResult = await _sut.AuthorizeAsync(note, ResourceAction.Delete);
+
+        // Assert
+        readResult.IsError.ShouldBeFalse();
+        updateResult.IsError.ShouldBeFalse();
+        deleteResult.IsError.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenSharedUser_CanOnlyRead()
+    {
+        // Arrange
+        var sharedUserId = UserId.New();
+        var user = CreateUser(sharedUserId);
+        _currentUserProvider.CurrentUser.Returns(user);
+
+        var creatorId = UserId.New();
+        var note = Note.Create("Test", "Body", creatorId);
+        note.ShareWith(sharedUserId);
+
+        // Act
+        var readResult = await _sut.AuthorizeAsync(note, ResourceAction.Read);
+        var updateResult = await _sut.AuthorizeAsync(note, ResourceAction.Update);
+        var deleteResult = await _sut.AuthorizeAsync(note, ResourceAction.Delete);
+
+        // Assert
+        readResult.IsError.ShouldBeFalse();
+        updateResult.IsError.ShouldBeTrue();
+        updateResult.FirstError.Code.ShouldBe("Note.ModifyDenied");
+        deleteResult.IsError.ShouldBeTrue();
+        deleteResult.FirstError.Code.ShouldBe("Note.ModifyDenied");
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenUnrelatedUser_CannotReadOrModify()
+    {
+        // Arrange
+        var unrelatedUserId = UserId.New();
+        var user = CreateUser(unrelatedUserId);
+        _currentUserProvider.CurrentUser.Returns(user);
+
+        var creatorId = UserId.New();
+        var note = Note.Create("Test", "Body", creatorId);
+
+        // Act
+        var readResult = await _sut.AuthorizeAsync(note, ResourceAction.Read);
+        var updateResult = await _sut.AuthorizeAsync(note, ResourceAction.Update);
+        var deleteResult = await _sut.AuthorizeAsync(note, ResourceAction.Delete);
+
+        // Assert
+        readResult.IsError.ShouldBeTrue();
+        readResult.FirstError.Code.ShouldBe("Note.AccessDenied");
+        updateResult.IsError.ShouldBeTrue();
+        updateResult.FirstError.Code.ShouldBe("Note.ModifyDenied");
+        deleteResult.IsError.ShouldBeTrue();
+        deleteResult.FirstError.Code.ShouldBe("Note.ModifyDenied");
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_ForUnknownResource_AllowsAccess()
+    {
+        // Arrange
+        var user = CreateUser();
+        _currentUserProvider.CurrentUser.Returns(user);
+        var unknownResource = new { Name = "Unknown" };
+
+        // Act
+        var result = await _sut.AuthorizeAsync(unknownResource, ResourceAction.Read);
+
+        // Assert
+        result.IsError.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CurrentUser_ReturnsCurrentUser()
+    {
+        // Arrange
+        var user = CreateUser();
+        _currentUserProvider.CurrentUser.Returns(user);
+
+        // Act
+        var result = _sut.CurrentUser;
+
+        // Assert
+        result.ShouldBe(user);
+    }
+
+    [Fact]
+    public void IsAdmin_WhenUserIsAdmin_ReturnsTrue()
+    {
+        // Arrange
+        var adminUser = CreateUser(isAdmin: true);
+        _currentUserProvider.CurrentUser.Returns(adminUser);
+
+        // Act
+        var result = _sut.IsAdmin;
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsAdmin_WhenUserIsNotAdmin_ReturnsFalse()
+    {
+        // Arrange
+        var user = CreateUser(isAdmin: false);
+        _currentUserProvider.CurrentUser.Returns(user);
+
+        // Act
+        var result = _sut.IsAdmin;
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    private static CurrentUser CreateUser(UserId? userId = null, bool isAdmin = false)
+    {
+        IReadOnlyList<string> roles = isAdmin
+            ? [WellKnownRoles.Admin, WellKnownRoles.User]
+            : [WellKnownRoles.User];
+
+        return new CurrentUser
+        {
+            Id = userId ?? UserId.New(),
+            Email = "test@example.com",
+            Name = "Test User",
+            Roles = roles,
+            IsAuthenticated = true
+        };
+    }
+}

--- a/tests/OpenTicket.Application.Tests/Authorization/AuthorizationServiceTests.cs
+++ b/tests/OpenTicket.Application.Tests/Authorization/AuthorizationServiceTests.cs
@@ -194,8 +194,8 @@ public class AuthorizationServiceTests
     private static CurrentUser CreateUser(UserId? userId = null, bool isAdmin = false)
     {
         IReadOnlyList<string> roles = isAdmin
-            ? [WellKnownRoles.Admin, WellKnownRoles.User]
-            : [WellKnownRoles.User];
+            ? [Roles.Admin, Roles.User]
+            : [Roles.User];
 
         return new CurrentUser
         {

--- a/tests/OpenTicket.Application.Tests/OpenTicket.Application.Tests.csproj
+++ b/tests/OpenTicket.Application.Tests/OpenTicket.Application.Tests.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenTicket.Application\OpenTicket.Application.csproj" />
+    <ProjectReference Include="..\..\src\OpenTicket.Infrastructure.Cache\OpenTicket.Infrastructure.Cache.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/OpenTicket.Application.Tests/RateLimiting/RateLimitServiceTests.cs
+++ b/tests/OpenTicket.Application.Tests/RateLimiting/RateLimitServiceTests.cs
@@ -1,0 +1,329 @@
+using NSubstitute;
+using OpenTicket.Application.Contracts.Identity;
+using OpenTicket.Application.Contracts.RateLimiting;
+using OpenTicket.Application.RateLimiting;
+using OpenTicket.Domain.Shared.Identities;
+using OpenTicket.Infrastructure.Cache.Abstractions;
+using Shouldly;
+
+namespace OpenTicket.Application.Tests.RateLimiting;
+
+public class RateLimitServiceTests
+{
+    private readonly IDistributedCache _cache;
+    private readonly ICurrentUserProvider _currentUserProvider;
+    private readonly RateLimitService _sut;
+
+    public RateLimitServiceTests()
+    {
+        _cache = Substitute.For<IDistributedCache>();
+        _currentUserProvider = Substitute.For<ICurrentUserProvider>();
+        _sut = new RateLimitService(_cache, _currentUserProvider);
+    }
+
+    #region CheckRateLimitAsync
+
+    [Fact]
+    public async Task CheckRateLimitAsync_WhenAdmin_AlwaysAllows()
+    {
+        // Arrange
+        var adminUser = CreateUser(isAdmin: true);
+        _currentUserProvider.CurrentUser.Returns(adminUser);
+
+        // Act
+        var result = await _sut.CheckRateLimitAsync(adminUser.Id, RateLimitedAction.CreateNote);
+
+        // Assert
+        result.IsError.ShouldBeFalse();
+        await _cache.DidNotReceive().GetAsync<int?>(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CheckRateLimitAsync_WhenSubscriber_AlwaysAllows()
+    {
+        // Arrange
+        var subscriberUser = CreateUser(hasSubscription: true);
+        _currentUserProvider.CurrentUser.Returns(subscriberUser);
+
+        // Act
+        var result = await _sut.CheckRateLimitAsync(subscriberUser.Id, RateLimitedAction.CreateNote);
+
+        // Assert
+        result.IsError.ShouldBeFalse();
+        await _cache.DidNotReceive().GetAsync<int?>(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CheckRateLimitAsync_WhenNonSubscriberUnderLimit_AllowsAccess()
+    {
+        // Arrange
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+        _currentUserProvider.CurrentUser.Returns(user);
+        _cache.GetAsync<int?>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(2); // Under limit of 3
+
+        // Act
+        var result = await _sut.CheckRateLimitAsync(userId, RateLimitedAction.CreateNote);
+
+        // Assert
+        result.IsError.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CheckRateLimitAsync_WhenNonSubscriberAtLimit_DeniesAccess()
+    {
+        // Arrange
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+        _currentUserProvider.CurrentUser.Returns(user);
+        _cache.GetAsync<int?>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(3); // At limit of 3
+
+        // Act
+        var result = await _sut.CheckRateLimitAsync(userId, RateLimitedAction.CreateNote);
+
+        // Assert
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Code.ShouldBe("RateLimit.Exceeded");
+    }
+
+    [Fact]
+    public async Task CheckRateLimitAsync_WhenNonSubscriberOverLimit_DeniesAccess()
+    {
+        // Arrange
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+        _currentUserProvider.CurrentUser.Returns(user);
+        _cache.GetAsync<int?>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(10); // Over limit of 3
+
+        // Act
+        var result = await _sut.CheckRateLimitAsync(userId, RateLimitedAction.CreateNote);
+
+        // Assert
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Code.ShouldBe("RateLimit.Exceeded");
+    }
+
+    [Fact]
+    public async Task CheckRateLimitAsync_WhenNoCountInCache_AllowsAccess()
+    {
+        // Arrange
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+        _currentUserProvider.CurrentUser.Returns(user);
+        _cache.GetAsync<int?>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((int?)null);
+
+        // Act
+        var result = await _sut.CheckRateLimitAsync(userId, RateLimitedAction.CreateNote);
+
+        // Assert
+        result.IsError.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region RecordActionAsync
+
+    [Fact]
+    public async Task RecordActionAsync_WhenAdmin_DoesNotRecordAction()
+    {
+        // Arrange
+        var adminUser = CreateUser(isAdmin: true);
+        _currentUserProvider.CurrentUser.Returns(adminUser);
+
+        // Act
+        await _sut.RecordActionAsync(adminUser.Id, RateLimitedAction.CreateNote);
+
+        // Assert
+        await _cache.DidNotReceive().SetAsync(
+            Arg.Any<string>(),
+            Arg.Any<int>(),
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RecordActionAsync_WhenSubscriber_DoesNotRecordAction()
+    {
+        // Arrange
+        var subscriberUser = CreateUser(hasSubscription: true);
+        _currentUserProvider.CurrentUser.Returns(subscriberUser);
+
+        // Act
+        await _sut.RecordActionAsync(subscriberUser.Id, RateLimitedAction.CreateNote);
+
+        // Assert
+        await _cache.DidNotReceive().SetAsync(
+            Arg.Any<string>(),
+            Arg.Any<int>(),
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RecordActionAsync_WhenNonSubscriber_IncrementsCount()
+    {
+        // Arrange
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+        _currentUserProvider.CurrentUser.Returns(user);
+        _cache.GetAsync<int?>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(2);
+
+        // Act
+        await _sut.RecordActionAsync(userId, RateLimitedAction.CreateNote);
+
+        // Assert
+        await _cache.Received(1).SetAsync(
+            Arg.Any<string>(),
+            3, // Incremented from 2 to 3
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RecordActionAsync_WhenNoExistingCount_SetsCountToOne()
+    {
+        // Arrange
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+        _currentUserProvider.CurrentUser.Returns(user);
+        _cache.GetAsync<int?>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((int?)null);
+
+        // Act
+        await _sut.RecordActionAsync(userId, RateLimitedAction.CreateNote);
+
+        // Assert
+        await _cache.Received(1).SetAsync(
+            Arg.Any<string>(),
+            1, // First action
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region GetRemainingQuotaAsync
+
+    [Fact]
+    public async Task GetRemainingQuotaAsync_WhenAdmin_ReturnsUnlimited()
+    {
+        // Arrange
+        var adminUser = CreateUser(isAdmin: true);
+        _currentUserProvider.CurrentUser.Returns(adminUser);
+
+        // Act
+        var result = await _sut.GetRemainingQuotaAsync(adminUser.Id, RateLimitedAction.CreateNote);
+
+        // Assert
+        result.ShouldBe(-1); // -1 means unlimited
+    }
+
+    [Fact]
+    public async Task GetRemainingQuotaAsync_WhenSubscriber_ReturnsUnlimited()
+    {
+        // Arrange
+        var subscriberUser = CreateUser(hasSubscription: true);
+        _currentUserProvider.CurrentUser.Returns(subscriberUser);
+
+        // Act
+        var result = await _sut.GetRemainingQuotaAsync(subscriberUser.Id, RateLimitedAction.CreateNote);
+
+        // Assert
+        result.ShouldBe(-1); // -1 means unlimited
+    }
+
+    [Fact]
+    public async Task GetRemainingQuotaAsync_WhenNonSubscriberWithNoActions_ReturnsFullQuota()
+    {
+        // Arrange
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+        _currentUserProvider.CurrentUser.Returns(user);
+        _cache.GetAsync<int?>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((int?)null);
+
+        // Act
+        var result = await _sut.GetRemainingQuotaAsync(userId, RateLimitedAction.CreateNote);
+
+        // Assert
+        result.ShouldBe(3); // Full quota of 3
+    }
+
+    [Fact]
+    public async Task GetRemainingQuotaAsync_WhenNonSubscriberWithSomeActions_ReturnsRemainingQuota()
+    {
+        // Arrange
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+        _currentUserProvider.CurrentUser.Returns(user);
+        _cache.GetAsync<int?>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(2);
+
+        // Act
+        var result = await _sut.GetRemainingQuotaAsync(userId, RateLimitedAction.CreateNote);
+
+        // Assert
+        result.ShouldBe(1); // 3 - 2 = 1 remaining
+    }
+
+    [Fact]
+    public async Task GetRemainingQuotaAsync_WhenNonSubscriberAtLimit_ReturnsZero()
+    {
+        // Arrange
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+        _currentUserProvider.CurrentUser.Returns(user);
+        _cache.GetAsync<int?>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(3);
+
+        // Act
+        var result = await _sut.GetRemainingQuotaAsync(userId, RateLimitedAction.CreateNote);
+
+        // Assert
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GetRemainingQuotaAsync_WhenNonSubscriberOverLimit_ReturnsZero()
+    {
+        // Arrange
+        var userId = UserId.New();
+        var user = CreateUser(userId);
+        _currentUserProvider.CurrentUser.Returns(user);
+        _cache.GetAsync<int?>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(10);
+
+        // Act
+        var result = await _sut.GetRemainingQuotaAsync(userId, RateLimitedAction.CreateNote);
+
+        // Assert
+        result.ShouldBe(0); // Math.Max(0, 3-10) = 0
+    }
+
+    #endregion
+
+    private static CurrentUser CreateUser(
+        UserId? userId = null,
+        bool isAdmin = false,
+        bool hasSubscription = false)
+    {
+        IReadOnlyList<string> roles = isAdmin
+            ? [WellKnownRoles.Admin, WellKnownRoles.User]
+            : [WellKnownRoles.User];
+
+        return new CurrentUser
+        {
+            Id = userId ?? UserId.New(),
+            Email = "test@example.com",
+            Name = "Test User",
+            Roles = roles,
+            IsAuthenticated = true,
+            HasSubscription = hasSubscription
+        };
+    }
+}

--- a/tests/OpenTicket.Application.Tests/RateLimiting/RateLimitServiceTests.cs
+++ b/tests/OpenTicket.Application.Tests/RateLimiting/RateLimitServiceTests.cs
@@ -313,8 +313,8 @@ public class RateLimitServiceTests
         bool hasSubscription = false)
     {
         IReadOnlyList<string> roles = isAdmin
-            ? [WellKnownRoles.Admin, WellKnownRoles.User]
-            : [WellKnownRoles.User];
+            ? [Roles.Admin, Roles.User]
+            : [Roles.User];
 
         return new CurrentUser
         {

--- a/tests/OpenTicket.Ddd.Tests/Application/Cqrs/Behaviors/AuthorizationBehaviorTests.cs
+++ b/tests/OpenTicket.Ddd.Tests/Application/Cqrs/Behaviors/AuthorizationBehaviorTests.cs
@@ -1,0 +1,177 @@
+using ErrorOr;
+using NSubstitute;
+using OpenTicket.Ddd.Application.Cqrs;
+using OpenTicket.Ddd.Application.Cqrs.Authorization;
+using OpenTicket.Ddd.Application.Cqrs.Behaviors;
+using Shouldly;
+
+namespace OpenTicket.Ddd.Tests.Application.Cqrs.Behaviors;
+
+public class AuthorizationBehaviorTests
+{
+    private readonly IRequestAuthorizationService _authorizationService;
+    private readonly AuthorizationBehavior<TestAuthorizeableCommand, ErrorOr<string>> _sut;
+
+    public AuthorizationBehaviorTests()
+    {
+        _authorizationService = Substitute.For<IRequestAuthorizationService>();
+        _sut = new AuthorizationBehavior<TestAuthorizeableCommand, ErrorOr<string>>(_authorizationService);
+    }
+
+    // Test command without [Authorize] attribute
+    public record TestAuthorizeableCommand : IAuthorizeableCommand<ErrorOr<string>>;
+
+    // Test command with [Authorize] attribute for roles
+    [Authorize(Roles = "Admin,User")]
+    public record TestAuthorizeableCommandWithRoles : IAuthorizeableCommand<ErrorOr<string>>;
+
+    // Test command with multiple [Authorize] attributes
+    [Authorize(Roles = "Admin")]
+    [Authorize(Permissions = "Note.Create,Note.Update")]
+    public record TestAuthorizeableCommandWithMultipleAttributes : IAuthorizeableCommand<ErrorOr<string>>;
+
+    [Fact]
+    public async Task HandleAsync_WithNoAuthorizeAttribute_ShouldProceedToNext()
+    {
+        // Arrange
+        var command = new TestAuthorizeableCommand();
+        var nextCalled = false;
+
+        // Act
+        var result = await _sut.HandleAsync(command, () =>
+        {
+            nextCalled = true;
+            return Task.FromResult<ErrorOr<string>>("Success");
+        });
+
+        // Assert
+        nextCalled.ShouldBeTrue();
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe("Success");
+        _authorizationService.DidNotReceive().AuthorizeCurrentUser(
+            Arg.Any<TestAuthorizeableCommand>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<IReadOnlyList<string>>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithAuthorizeAttribute_WhenAuthorized_ShouldProceedToNext()
+    {
+        // Arrange
+        var behavior = new AuthorizationBehavior<TestAuthorizeableCommandWithRoles, ErrorOr<string>>(_authorizationService);
+        var command = new TestAuthorizeableCommandWithRoles();
+
+        _authorizationService.AuthorizeCurrentUser(
+            Arg.Any<TestAuthorizeableCommandWithRoles>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<IReadOnlyList<string>>())
+            .Returns(Result.Success);
+
+        var nextCalled = false;
+
+        // Act
+        var result = await behavior.HandleAsync(command, () =>
+        {
+            nextCalled = true;
+            return Task.FromResult<ErrorOr<string>>("Success");
+        });
+
+        // Assert
+        nextCalled.ShouldBeTrue();
+        result.IsError.ShouldBeFalse();
+        result.Value.ShouldBe("Success");
+
+        _authorizationService.Received(1).AuthorizeCurrentUser(
+            command,
+            Arg.Is<IReadOnlyList<string>>(roles => roles.Contains("Admin") && roles.Contains("User")),
+            Arg.Is<IReadOnlyList<string>>(perms => perms.Count == 0),
+            Arg.Is<IReadOnlyList<string>>(policies => policies.Count == 0));
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithAuthorizeAttribute_WhenNotAuthorized_ShouldReturnErrors()
+    {
+        // Arrange
+        var behavior = new AuthorizationBehavior<TestAuthorizeableCommandWithRoles, ErrorOr<string>>(_authorizationService);
+        var command = new TestAuthorizeableCommandWithRoles();
+
+        var expectedError = Error.Forbidden(
+            "Authorization.MissingRole",
+            "User is missing required roles.");
+
+        _authorizationService.AuthorizeCurrentUser(
+            Arg.Any<TestAuthorizeableCommandWithRoles>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<IReadOnlyList<string>>())
+            .Returns(expectedError);
+
+        var nextCalled = false;
+
+        // Act
+        var result = await behavior.HandleAsync(command, () =>
+        {
+            nextCalled = true;
+            return Task.FromResult<ErrorOr<string>>("Success");
+        });
+
+        // Assert
+        nextCalled.ShouldBeFalse();
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Code.ShouldBe("Authorization.MissingRole");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithMultipleAuthorizeAttributes_ShouldCollectAllRequirements()
+    {
+        // Arrange
+        var behavior = new AuthorizationBehavior<TestAuthorizeableCommandWithMultipleAttributes, ErrorOr<string>>(_authorizationService);
+        var command = new TestAuthorizeableCommandWithMultipleAttributes();
+
+        _authorizationService.AuthorizeCurrentUser(
+            Arg.Any<TestAuthorizeableCommandWithMultipleAttributes>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<IReadOnlyList<string>>())
+            .Returns(Result.Success);
+
+        // Act
+        await behavior.HandleAsync(command, () => Task.FromResult<ErrorOr<string>>("Success"));
+
+        // Assert
+        _authorizationService.Received(1).AuthorizeCurrentUser(
+            command,
+            Arg.Is<IReadOnlyList<string>>(roles => roles.Contains("Admin")),
+            Arg.Is<IReadOnlyList<string>>(perms => perms.Contains("Note.Create") && perms.Contains("Note.Update")),
+            Arg.Is<IReadOnlyList<string>>(policies => policies.Count == 0));
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithUnauthenticatedUser_ShouldReturnUnauthorizedError()
+    {
+        // Arrange
+        var behavior = new AuthorizationBehavior<TestAuthorizeableCommandWithRoles, ErrorOr<string>>(_authorizationService);
+        var command = new TestAuthorizeableCommandWithRoles();
+
+        var expectedError = Error.Unauthorized(
+            "Authorization.Unauthenticated",
+            "User is not authenticated.");
+
+        _authorizationService.AuthorizeCurrentUser(
+            Arg.Any<TestAuthorizeableCommandWithRoles>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<IReadOnlyList<string>>())
+            .Returns(expectedError);
+
+        // Act
+        var result = await behavior.HandleAsync(command, () => Task.FromResult<ErrorOr<string>>("Success"));
+
+        // Assert
+        result.IsError.ShouldBeTrue();
+        result.FirstError.Code.ShouldBe("Authorization.Unauthenticated");
+        result.FirstError.Type.ShouldBe(ErrorType.Unauthorized);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `ICurrentUserProvider` and `ITokenService` interfaces in Application.Contracts
- Add Mock identity provider with `MockAuthenticationHandler` for development/testing
- Add OAuth identity with JWT Bearer authentication supporting Google, Facebook, GitHub, Microsoft, Apple
- Add `AuthorizationBehavior` AOP pattern for request-level authorization
- Add `AuthController` with login/callback/me/refresh endpoints
- Configure OpenAPI with JWT Bearer security scheme

## Changes
- **Application.Contracts/Identity**: `ICurrentUserProvider`, `ITokenService`, `CurrentUser`, `Roles`
- **Infrastructure.Identity/Mock**: `MockCurrentUserProvider`, `MockAuthenticationHandler`, `MockUserOptions`
- **Infrastructure.Identity/OAuth**: `JwtCurrentUserProvider`, `JwtTokenService`, `OAuthOptions`, `OAuthProviders`
- **Api**: `AuthController`, JWT Bearer OpenAPI config, `[Authorize]` on `ApiController`
- **Application/Cqrs**: `AuthorizationBehavior`, `IAuthorizeableRequest`, `IRequestAuthorizationService`

## Test plan
- [x] GitHub OAuth login returns JWT with user info (name, email)
- [x] `/api/auth/me` returns current user from JWT claims
- [x] Mock mode works with `AddMockIdentity()`
- [x] Protected endpoints return 401 without valid JWT
- [x] JWT token can be entered in Swagger/Scalar UI

Closes #5